### PR TITLE
Add icon keywords and groups for Umbraco 17.4 semantic search

### DIFF
--- a/Umbraco.Community.IconPack.Iconoir.Website/Umbraco.Community.IconPack.Iconoir.Website.csproj
+++ b/Umbraco.Community.IconPack.Iconoir.Website/Umbraco.Community.IconPack.Iconoir.Website.csproj
@@ -1,12 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Umbraco.Cms" Version="15.3.1" />
+    <PackageReference Include="Umbraco.Cms" Version="17.4.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Umbraco.Community.IconPack.Iconoir.Website/Umbraco.Community.IconPack.Iconoir.Website.csproj
+++ b/Umbraco.Community.IconPack.Iconoir.Website/Umbraco.Community.IconPack.Iconoir.Website.csproj
@@ -3,6 +3,7 @@
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <CompressionEnabled>false</CompressionEnabled>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Umbraco.Community.IconPack.Iconoir/Umbraco.Community.IconPack.Iconoir.csproj
+++ b/Umbraco.Community.IconPack.Iconoir/Umbraco.Community.IconPack.Iconoir.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>

--- a/Umbraco.Community.IconPack.Iconoir/Umbraco.Community.IconPack.Iconoir.csproj
+++ b/Umbraco.Community.IconPack.Iconoir/Umbraco.Community.IconPack.Iconoir.csproj
@@ -15,11 +15,11 @@
     <Title>Umbraco Icon Pack: Iconoir</Title>
     <Authors>warrenbuckley</Authors>
     <Company>Hack Make Do</Company>
-    <Description>An Umbraco V14 icon pack that uses the Iconoir open source icons</Description>
+    <Description>An Umbraco icon pack that uses the Iconoir open source icons, with keyword and group metadata for enhanced icon search (Umbraco 17.4+)</Description>
     <PackageProjectUrl>https://github.com/warrenbuckley/Umbraco.Iconpack.Iconoir/tree/master</PackageProjectUrl>
     <RepositoryUrl>https://github.com/warrenbuckley/Umbraco.Iconpack.Iconoir/tree/master</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
-    <PackageTags>umbraco-marketplace;umbraco;umbraco-v14;umbraco-iconpack;iconoir;</PackageTags>
+    <PackageTags>umbraco-marketplace;umbraco;umbraco-iconpack;iconoir;</PackageTags>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageIcon>Umbraco.Community.IconPacks.Iconoir.Logo.png</PackageIcon>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
@@ -56,7 +56,7 @@
     </None>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Umbraco.Cms" Version="15.3.1" />
+    <PackageReference Include="Umbraco.Cms" Version="17.4.0" />
   </ItemGroup>
 	
 </Project>

--- a/Umbraco.Community.IconPack.Iconoir/client/package-lock.json
+++ b/Umbraco.Community.IconPack.Iconoir/client/package-lock.json
@@ -11,16 +11,16 @@
         "iconoir": "^7.11.0"
       },
       "devDependencies": {
-        "@types/node": "^24.9.1",
+        "@types/node": "^25.8.0",
         "@umbraco-cms/backoffice": "^17.4.0",
-        "typescript": "^5.9.3",
-        "vite": "^7.1.12"
+        "typescript": "^6.0.3",
+        "vite": "^7.3.3"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.25.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.1.tgz",
-      "integrity": "sha512-kfYGy8IdzTGy+z0vFGvExZtxkFlA4zAxgKEahG9KE1ScBjpQnFsNOX8KTU5ojNru5ed5CVoJYXFtoxaq5nFbjQ==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
       "cpu": [
         "ppc64"
       ],
@@ -35,9 +35,9 @@
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.25.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.1.tgz",
-      "integrity": "sha512-dp+MshLYux6j/JjdqVLnMglQlFu+MuVeNrmT5nk6q07wNhCdSnB7QZj+7G8VMUGh1q+vj2Bq8kRsuyA00I/k+Q==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
       "cpu": [
         "arm"
       ],
@@ -52,9 +52,9 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.25.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.1.tgz",
-      "integrity": "sha512-50tM0zCJW5kGqgG7fQ7IHvQOcAn9TKiVRuQ/lN0xR+T2lzEFvAi1ZcS8DiksFcEpf1t/GYOeOfCAgDHFpkiSmA==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
       "cpu": [
         "arm64"
       ],
@@ -69,9 +69,9 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.25.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.1.tgz",
-      "integrity": "sha512-GCj6WfUtNldqUzYkN/ITtlhwQqGWu9S45vUXs7EIYf+7rCiiqH9bCloatO9VhxsL0Pji+PF4Lz2XXCES+Q8hDw==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
       "cpu": [
         "x64"
       ],
@@ -86,9 +86,9 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.25.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.1.tgz",
-      "integrity": "sha512-5hEZKPf+nQjYoSr/elb62U19/l1mZDdqidGfmFutVUjjUZrOazAtwK+Kr+3y0C/oeJfLlxo9fXb1w7L+P7E4FQ==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
       "cpu": [
         "arm64"
       ],
@@ -103,9 +103,9 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.25.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.1.tgz",
-      "integrity": "sha512-hxVnwL2Dqs3fM1IWq8Iezh0cX7ZGdVhbTfnOy5uURtao5OIVCEyj9xIzemDi7sRvKsuSdtCAhMKarxqtlyVyfA==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
       "cpu": [
         "x64"
       ],
@@ -120,9 +120,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.25.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.1.tgz",
-      "integrity": "sha512-1MrCZs0fZa2g8E+FUo2ipw6jw5qqQiH+tERoS5fAfKnRx6NXH31tXBKI3VpmLijLH6yriMZsxJtaXUyFt/8Y4A==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
       "cpu": [
         "arm64"
       ],
@@ -137,9 +137,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.25.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.1.tgz",
-      "integrity": "sha512-0IZWLiTyz7nm0xuIs0q1Y3QWJC52R8aSXxe40VUxm6BB1RNmkODtW6LHvWRrGiICulcX7ZvyH6h5fqdLu4gkww==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
       "cpu": [
         "x64"
       ],
@@ -154,9 +154,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.25.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.1.tgz",
-      "integrity": "sha512-NdKOhS4u7JhDKw9G3cY6sWqFcnLITn6SqivVArbzIaf3cemShqfLGHYMx8Xlm/lBit3/5d7kXvriTUGa5YViuQ==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
       "cpu": [
         "arm"
       ],
@@ -171,9 +171,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.25.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.1.tgz",
-      "integrity": "sha512-jaN3dHi0/DDPelk0nLcXRm1q7DNJpjXy7yWaWvbfkPvI+7XNSc/lDOnCLN7gzsyzgu6qSAmgSvP9oXAhP973uQ==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
       "cpu": [
         "arm64"
       ],
@@ -188,9 +188,9 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.25.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.1.tgz",
-      "integrity": "sha512-OJykPaF4v8JidKNGz8c/q1lBO44sQNUQtq1KktJXdBLn1hPod5rE/Hko5ugKKZd+D2+o1a9MFGUEIUwO2YfgkQ==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
       "cpu": [
         "ia32"
       ],
@@ -205,9 +205,9 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.25.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.1.tgz",
-      "integrity": "sha512-nGfornQj4dzcq5Vp835oM/o21UMlXzn79KobKlcs3Wz9smwiifknLy4xDCLUU0BWp7b/houtdrgUz7nOGnfIYg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
       "cpu": [
         "loong64"
       ],
@@ -222,9 +222,9 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.25.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.1.tgz",
-      "integrity": "sha512-1osBbPEFYwIE5IVB/0g2X6i1qInZa1aIoj1TdL4AaAb55xIIgbg8Doq6a5BzYWgr+tEcDzYH67XVnTmUzL+nXg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
       "cpu": [
         "mips64el"
       ],
@@ -239,9 +239,9 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.25.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.1.tgz",
-      "integrity": "sha512-/6VBJOwUf3TdTvJZ82qF3tbLuWsscd7/1w+D9LH0W/SqUgM5/JJD0lrJ1fVIfZsqB6RFmLCe0Xz3fmZc3WtyVg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
       "cpu": [
         "ppc64"
       ],
@@ -256,9 +256,9 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.25.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.1.tgz",
-      "integrity": "sha512-nSut/Mx5gnilhcq2yIMLMe3Wl4FK5wx/o0QuuCLMtmJn+WeWYoEGDN1ipcN72g1WHsnIbxGXd4i/MF0gTcuAjQ==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
       "cpu": [
         "riscv64"
       ],
@@ -273,9 +273,9 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.25.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.1.tgz",
-      "integrity": "sha512-cEECeLlJNfT8kZHqLarDBQso9a27o2Zd2AQ8USAEoGtejOrCYHNtKP8XQhMDJMtthdF4GBmjR2au3x1udADQQQ==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
       "cpu": [
         "s390x"
       ],
@@ -290,9 +290,9 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.25.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.1.tgz",
-      "integrity": "sha512-xbfUhu/gnvSEg+EGovRc+kjBAkrvtk38RlerAzQxvMzlB4fXpCFCeUAYzJvrnhFtdeyVCDANSjJvOvGYoeKzFA==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
       "cpu": [
         "x64"
       ],
@@ -307,9 +307,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.25.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.1.tgz",
-      "integrity": "sha512-O96poM2XGhLtpTh+s4+nP7YCCAfb4tJNRVZHfIE7dgmax+yMP2WgMd2OecBuaATHKTHsLWHQeuaxMRnCsH8+5g==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
       "cpu": [
         "arm64"
       ],
@@ -324,9 +324,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.25.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.1.tgz",
-      "integrity": "sha512-X53z6uXip6KFXBQ+Krbx25XHV/NCbzryM6ehOAeAil7X7oa4XIq+394PWGnwaSQ2WRA0KI6PUO6hTO5zeF5ijA==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
       "cpu": [
         "x64"
       ],
@@ -341,9 +341,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.25.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.1.tgz",
-      "integrity": "sha512-Na9T3szbXezdzM/Kfs3GcRQNjHzM6GzFBeU1/6IV/npKP5ORtp9zbQjvkDJ47s6BCgaAZnnnu/cY1x342+MvZg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
       "cpu": [
         "arm64"
       ],
@@ -358,9 +358,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.25.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.1.tgz",
-      "integrity": "sha512-T3H78X2h1tszfRSf+txbt5aOp/e7TAz3ptVKu9Oyir3IAOFPGV6O9c2naym5TOriy1l0nNf6a4X5UXRZSGX/dw==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
       "cpu": [
         "x64"
       ],
@@ -374,10 +374,27 @@
         "node": ">=18"
       }
     },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.25.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.1.tgz",
-      "integrity": "sha512-2H3RUvcmULO7dIE5EWJH8eubZAI4xw54H1ilJnRNZdeo8dTADEZ21w6J22XBkXqGJbe0+wnNJtw3UXRoLJnFEg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
       "cpu": [
         "x64"
       ],
@@ -392,9 +409,9 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.25.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.1.tgz",
-      "integrity": "sha512-GE7XvrdOzrb+yVKB9KsRMq+7a2U/K5Cf/8grVFRAGJmfADr/e/ODQ134RK2/eeHqYV5eQRFxb1hY7Nr15fv1NQ==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
       "cpu": [
         "arm64"
       ],
@@ -409,9 +426,9 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.25.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.1.tgz",
-      "integrity": "sha512-uOxSJCIcavSiT6UnBhBzE8wy3n0hOkJsBOzy7HDAuTDE++1DJMRRVCPGisULScHL+a/ZwdXPpXD3IyFKjA7K8A==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
       "cpu": [
         "ia32"
       ],
@@ -426,9 +443,9 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.25.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.1.tgz",
-      "integrity": "sha512-Y1EQdcfwMSeQN/ujR5VayLOJ1BHaK+ssyk0AEzPjC+t1lITgsnccPqFjb6V+LsTp/9Iov4ysfjxLaGJ9RPtkVg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
       "cpu": [
         "x64"
       ],
@@ -1465,13 +1482,13 @@
       "peer": true
     },
     "node_modules/@types/node": {
-      "version": "24.9.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.9.1.tgz",
-      "integrity": "sha512-QoiaXANRkSXK6p0Duvt56W208du4P9Uye9hWLWgGMDTEoKPhuenzNcC4vGUmrNkiOKTlIrBoyNQYNpSwfEZXSg==",
+      "version": "25.8.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.8.0.tgz",
+      "integrity": "sha512-TCFSk8IZh+iLX1xtksoBVtdmgL+1IX0fC9BeU4QqFSuNdN/K+HUlhqOzEmSYYpZUVsLYcPqc9KX+60iDuninSQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.16.0"
+        "undici-types": ">=7.24.0 <7.24.7"
       }
     },
     "node_modules/@types/trusted-types": {
@@ -2868,9 +2885,9 @@
       "peer": true
     },
     "node_modules/esbuild": {
-      "version": "0.25.1",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.1.tgz",
-      "integrity": "sha512-BGO5LtrGC7vxnqucAe/rmvKdJllfGaYWdyABvyMoXQlfYMb2bbRuReWR5tEGE//4LcNJj9XrkovTqNYRFZHAMQ==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -2881,31 +2898,32 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.25.1",
-        "@esbuild/android-arm": "0.25.1",
-        "@esbuild/android-arm64": "0.25.1",
-        "@esbuild/android-x64": "0.25.1",
-        "@esbuild/darwin-arm64": "0.25.1",
-        "@esbuild/darwin-x64": "0.25.1",
-        "@esbuild/freebsd-arm64": "0.25.1",
-        "@esbuild/freebsd-x64": "0.25.1",
-        "@esbuild/linux-arm": "0.25.1",
-        "@esbuild/linux-arm64": "0.25.1",
-        "@esbuild/linux-ia32": "0.25.1",
-        "@esbuild/linux-loong64": "0.25.1",
-        "@esbuild/linux-mips64el": "0.25.1",
-        "@esbuild/linux-ppc64": "0.25.1",
-        "@esbuild/linux-riscv64": "0.25.1",
-        "@esbuild/linux-s390x": "0.25.1",
-        "@esbuild/linux-x64": "0.25.1",
-        "@esbuild/netbsd-arm64": "0.25.1",
-        "@esbuild/netbsd-x64": "0.25.1",
-        "@esbuild/openbsd-arm64": "0.25.1",
-        "@esbuild/openbsd-x64": "0.25.1",
-        "@esbuild/sunos-x64": "0.25.1",
-        "@esbuild/win32-arm64": "0.25.1",
-        "@esbuild/win32-ia32": "0.25.1",
-        "@esbuild/win32-x64": "0.25.1"
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
       }
     },
     "node_modules/event-target-shim": {
@@ -3823,9 +3841,9 @@
       "peer": true
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -3837,9 +3855,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
-      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
       "dev": true,
       "license": "MIT"
     },
@@ -3882,13 +3900,13 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.1.12",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.1.12.tgz",
-      "integrity": "sha512-ZWyE8YXEXqJrrSLvYgrRP7p62OziLW7xI5HYGWFzOvupfAlrLvURSzv/FyGyy0eidogEM3ujU+kUG1zuHgb6Ug==",
+      "version": "7.3.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.3.tgz",
+      "integrity": "sha512-/4XH147Ui7OGTjg3HbdWe5arnZQSbfuRzdr9Ec7TQi5I7R+ir0Rlc9GIvD4v0XZurELqA035KVXJXpR61xhiTA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "esbuild": "^0.25.0",
+        "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
         "picomatch": "^4.0.3",
         "postcss": "^8.5.6",

--- a/Umbraco.Community.IconPack.Iconoir/client/package-lock.json
+++ b/Umbraco.Community.IconPack.Iconoir/client/package-lock.json
@@ -12,7 +12,7 @@
       },
       "devDependencies": {
         "@types/node": "^24.9.1",
-        "@umbraco-cms/backoffice": "^15.3.1",
+        "@umbraco-cms/backoffice": "^17.4.0",
         "typescript": "^5.9.3",
         "vite": "^7.1.12"
       }
@@ -442,32 +442,186 @@
         "node": ">=18"
       }
     },
+    "node_modules/@heximal/expressions": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/@heximal/expressions/-/expressions-0.1.5.tgz",
+      "integrity": "sha512-QdWz9vNrdzi24so9KGEM9w4UYLg1yk+LVvYBEDbw9EY1BzKHITWdtYc55xJ3Zuio0/9Naz/D1YtYlCnfsycNDQ==",
+      "dev": true,
+      "license": "BSD 3-Clause",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.7.0"
+      }
+    },
+    "node_modules/@hey-api/codegen-core": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@hey-api/codegen-core/-/codegen-core-0.8.1.tgz",
+      "integrity": "sha512-Iciv2vUCJTW9lWM/ROvyZLblmcbYJHPuXfzb1SzeDVVn4xEXu2ilLU1pq3fn+09FZ/Y0P7VyvRE47UDU6om8xA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@hey-api/types": "0.1.4",
+        "ansi-colors": "4.1.3",
+        "c12": "3.3.4",
+        "color-support": "1.1.3"
+      },
+      "engines": {
+        "node": ">=22.13.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/hey-api"
+      }
+    },
+    "node_modules/@hey-api/json-schema-ref-parser": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@hey-api/json-schema-ref-parser/-/json-schema-ref-parser-1.4.2.tgz",
+      "integrity": "sha512-ZhCFSKI2ipZHEbgmtUHdyddvRU3wJ4elgCfYUC7T7hZa4EivSrVflTQf2w+v3TuaYxR1Y2V2kq3otqTttrrK8Q==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@jsdevtools/ono": "7.1.3",
+        "@types/json-schema": "7.0.15",
+        "js-yaml": "4.1.1"
+      },
+      "engines": {
+        "node": ">=22.13.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/hey-api"
+      }
+    },
+    "node_modules/@hey-api/openapi-ts": {
+      "version": "0.97.1",
+      "resolved": "https://registry.npmjs.org/@hey-api/openapi-ts/-/openapi-ts-0.97.1.tgz",
+      "integrity": "sha512-LksUJeXAqwf6OhcCCr3/B4YjnBs5rqSqjDUKMBvkgp4OhaCQiJrOvntctFxdnugy8jUojP4yi/eJf5xYzcYzCQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@hey-api/codegen-core": "0.8.1",
+        "@hey-api/json-schema-ref-parser": "1.4.2",
+        "@hey-api/shared": "0.4.3",
+        "@hey-api/spec-types": "0.2.0",
+        "@hey-api/types": "0.1.4",
+        "@lukeed/ms": "2.0.2",
+        "ansi-colors": "4.1.3",
+        "color-support": "1.1.3",
+        "commander": "14.0.3",
+        "get-tsconfig": "4.14.0"
+      },
+      "bin": {
+        "openapi-ts": "bin/run.js"
+      },
+      "engines": {
+        "node": ">=22.13.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/hey-api"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.5.3 || >=6.0.0 || 6.0.1-rc"
+      }
+    },
+    "node_modules/@hey-api/shared": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@hey-api/shared/-/shared-0.4.3.tgz",
+      "integrity": "sha512-3tHfZNXgGOt+3P3Kq9cvqmZ9i7e3jtrkip1uDpZTX1+hTNboHhYdjxnT8AbrDuvslTaQHoAOlP4/iCDdzd9Jag==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@hey-api/codegen-core": "0.8.1",
+        "@hey-api/json-schema-ref-parser": "1.4.2",
+        "@hey-api/spec-types": "0.2.0",
+        "@hey-api/types": "0.1.4",
+        "ansi-colors": "4.1.3",
+        "cross-spawn": "7.0.6",
+        "open": "11.0.0",
+        "semver": "7.7.4"
+      },
+      "engines": {
+        "node": ">=22.13.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/hey-api"
+      }
+    },
+    "node_modules/@hey-api/spec-types": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@hey-api/spec-types/-/spec-types-0.2.0.tgz",
+      "integrity": "sha512-ibQ8Is7evMavzr8GNyJCcTg975d8DpaMUyLmOrQ85UBdy1l6t1KuRAwgChAbesJsIlNV6gjmlXruWyegDX18Fg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@hey-api/types": "0.1.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/hey-api"
+      }
+    },
+    "node_modules/@hey-api/types": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@hey-api/types/-/types-0.1.4.tgz",
+      "integrity": "sha512-thWfawrDIP7wSI9ioT13I5soaaqB5vAPIiZmgD8PbeEVKNrkonc0N/Sjj97ezl7oQgusZmaNphGdMKipPO6IBg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@jsdevtools/ono": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
+      "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/@lit-labs/ssr-dom-shim": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.3.0.tgz",
-      "integrity": "sha512-nQIWonJ6eFAvUUrSlwyHDm/aE8PBDu5kRpL0vHMg6K8fK3Diq1xdPjTnsJSwxABhaZ+5eBi1btQB5ShUTKo4nQ==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.6.0.tgz",
+      "integrity": "sha512-VHb0ALPMTlgKjM6yIxxoQNnpKyUKLD04VzeQdsiXkMqkvYlAHxq9glGLmgbb889/1GsohSOAjvQYoiBppXFqrQ==",
       "dev": true,
       "license": "BSD-3-Clause",
       "peer": true
     },
     "node_modules/@lit/reactive-element": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-2.0.4.tgz",
-      "integrity": "sha512-GFn91inaUa2oHLak8awSIigYz0cU0Payr1rcFsrkf5OJ5eSPxElyZfKh0f2p9FsTiZWXQdWGJeXZICEfXXYSXQ==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-2.1.2.tgz",
+      "integrity": "sha512-pbCDiVMnne1lYUIaYNN5wrwQXDtHaYtg7YEFPeW+hws6U47WeFvISGUWekPGKWOP1ygrs0ef0o1VJMk1exos5A==",
       "dev": true,
       "license": "BSD-3-Clause",
       "peer": true,
       "dependencies": {
-        "@lit-labs/ssr-dom-shim": "^1.2.0"
+        "@lit-labs/ssr-dom-shim": "^1.5.0"
       }
     },
-    "node_modules/@remirror/core-constants": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-3.0.0.tgz",
-      "integrity": "sha512-42aWfPrimMfDKDi4YegyS7x+/0tlzaqwPQCULLanv3DMIlu96KTJR0fM5isWX2UViOqlGnX6YFgqWepcX+XMNg==",
+    "node_modules/@lukeed/ms": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@lukeed/ms/-/ms-2.0.2.tgz",
+      "integrity": "sha512-9I2Zn6+NJLfaGoz9jN3lpwDgAYvfGeNYdbAIjJOqzs4Tpc+VU3Jqq4IofSUBKajiDS8k9fZIg18/z13mpk1bsA==",
       "dev": true,
       "license": "MIT",
-      "peer": true
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@microsoft/signalr": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/signalr/-/signalr-10.0.0.tgz",
+      "integrity": "sha512-0BRqz/uCx3JdrOqiqgFhih/+hfTERaUfCZXFB52uMaZJrKaPRzHzMuqVsJC/V3pt7NozcNXGspjKiQEK+X7P2w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "eventsource": "^2.0.2",
+        "fetch-cookie": "^2.0.3",
+        "node-fetch": "^2.6.7",
+        "ws": "^7.5.10"
+      }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.52.5",
@@ -778,9 +932,9 @@
       ]
     },
     "node_modules/@tiptap/core": {
-      "version": "2.11.5",
-      "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-2.11.5.tgz",
-      "integrity": "sha512-jb0KTdUJaJY53JaN7ooY3XAxHQNoMYti/H6ANo707PsLXVeEqJ9o8+eBup1JU5CuwzrgnDc2dECt2WIGX9f8Jw==",
+      "version": "3.23.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-3.23.4.tgz",
+      "integrity": "sha512-ni2LWE52bVeSt3L2HVBSmbBw+elc32ATej9C68EyKzN/8vR5ILxFn6RCdDTKm4asmwZyq2jys12dKmBdWMr9QA==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -789,13 +943,13 @@
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/pm": "^2.7.0"
+        "@tiptap/pm": "3.23.4"
       }
     },
     "node_modules/@tiptap/extension-blockquote": {
-      "version": "2.11.5",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-blockquote/-/extension-blockquote-2.11.5.tgz",
-      "integrity": "sha512-MZfcRIzKRD8/J1hkt/eYv49060GTL6qGR3NY/oTDuw2wYzbQXXLEbjk8hxAtjwNn7G+pWQv3L+PKFzZDxibLuA==",
+      "version": "3.23.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-blockquote/-/extension-blockquote-3.23.4.tgz",
+      "integrity": "sha512-7YjSibNlPcy9eGK+tHt5G/Njr7nPxl+rZ3rCC6TwtLIRLSHPnoGDsfFOgTPkXxaQcE1a/VQwemnYfWc3kdIjDQ==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -804,13 +958,13 @@
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.7.0"
+        "@tiptap/core": "3.23.4"
       }
     },
     "node_modules/@tiptap/extension-bold": {
-      "version": "2.11.5",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-bold/-/extension-bold-2.11.5.tgz",
-      "integrity": "sha512-OAq03MHEbl7MtYCUzGuwb0VpOPnM0k5ekMbEaRILFU5ZC7cEAQ36XmPIw1dQayrcuE8GZL35BKub2qtRxyC9iA==",
+      "version": "3.23.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-bold/-/extension-bold-3.23.4.tgz",
+      "integrity": "sha512-3L9tnZ12i+98u5df2nV2zGu/sc3rhI87E3ocn1YYAO8PJUAgZnMwdet8JawCrS1uut5sRKlxo3SXEmdNfRVm/w==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -819,13 +973,13 @@
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.7.0"
+        "@tiptap/core": "3.23.4"
       }
     },
     "node_modules/@tiptap/extension-bullet-list": {
-      "version": "2.11.5",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-bullet-list/-/extension-bullet-list-2.11.5.tgz",
-      "integrity": "sha512-VXwHlX6A/T6FAspnyjbKDO0TQ+oetXuat6RY1/JxbXphH42nLuBaGWJ6pgy6xMl6XY8/9oPkTNrfJw/8/eeRwA==",
+      "version": "3.23.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-bullet-list/-/extension-bullet-list-3.23.4.tgz",
+      "integrity": "sha512-mXB2KZOz1R+E6VNTZ3vzdAk7ZDGKjPmsJEZIQg1B5qRycTKg49/rCCkLA2QnqAwX6BzS3mLLH1RWE2W0oXD7vg==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -834,13 +988,13 @@
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.7.0"
+        "@tiptap/extension-list": "3.23.4"
       }
     },
     "node_modules/@tiptap/extension-code": {
-      "version": "2.11.5",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-code/-/extension-code-2.11.5.tgz",
-      "integrity": "sha512-xOvHevNIQIcCCVn9tpvXa1wBp0wHN/2umbAZGTVzS+AQtM7BTo0tz8IyzwxkcZJaImONcUVYLOLzt2AgW1LltA==",
+      "version": "3.23.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-code/-/extension-code-3.23.4.tgz",
+      "integrity": "sha512-C0TeRipMycUEBnV+Mzx6eLp/yZb6Vi/waP3Tkb0lO5/ikg7LWLB7AlmMunjIXEUcR/pJHID/aEh5PfJFpysUDg==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -849,13 +1003,13 @@
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.7.0"
+        "@tiptap/core": "3.23.4"
       }
     },
     "node_modules/@tiptap/extension-code-block": {
-      "version": "2.11.5",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-code-block/-/extension-code-block-2.11.5.tgz",
-      "integrity": "sha512-ksxMMvqLDlC+ftcQLynqZMdlJT1iHYZorXsXw/n+wuRd7YElkRkd6YWUX/Pq/njFY6lDjKiqFLEXBJB8nrzzBA==",
+      "version": "3.23.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-code-block/-/extension-code-block-3.23.4.tgz",
+      "integrity": "sha512-UEU1w/85CSNKktbhESnIRmtjKcH7DeschReZA8err1wAnYLTKzid5ucnJSJ25iRg2V5Fnuws5gnPT5CVgdfXCQ==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -864,14 +1018,14 @@
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.7.0",
-        "@tiptap/pm": "^2.7.0"
+        "@tiptap/core": "3.23.4",
+        "@tiptap/pm": "3.23.4"
       }
     },
     "node_modules/@tiptap/extension-document": {
-      "version": "2.11.5",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-document/-/extension-document-2.11.5.tgz",
-      "integrity": "sha512-7I4BRTpIux2a0O2qS3BDmyZ5LGp3pszKbix32CmeVh7lN9dV7W5reDqtJJ9FCZEEF+pZ6e1/DQA362dflwZw2g==",
+      "version": "3.23.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-document/-/extension-document-3.23.4.tgz",
+      "integrity": "sha512-YC4G6VkxT629rlqUTwD6XvOpxjvghn7fxrK4RbyKVJY2C6E1vgmX0won1Ast6v+qTE6iONOMS6f6VyPxSGjg4w==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -880,13 +1034,13 @@
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.7.0"
+        "@tiptap/core": "3.23.4"
       }
     },
     "node_modules/@tiptap/extension-dropcursor": {
-      "version": "2.11.5",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-dropcursor/-/extension-dropcursor-2.11.5.tgz",
-      "integrity": "sha512-uIN7L3FU0904ec7FFFbndO7RQE/yiON4VzAMhNn587LFMyWO8US139HXIL4O8dpZeYwYL3d1FnDTflZl6CwLlg==",
+      "version": "3.23.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-dropcursor/-/extension-dropcursor-3.23.4.tgz",
+      "integrity": "sha512-ujJQUIENk0RwVFCh5g/TOSEv1a7Pnam/cjHmSUqHWUNZkYS9aOqjm+JfURJPCinRS2oHvo3AARul5mkKgDJYcA==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -895,14 +1049,13 @@
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.7.0",
-        "@tiptap/pm": "^2.7.0"
+        "@tiptap/extensions": "3.23.4"
       }
     },
     "node_modules/@tiptap/extension-gapcursor": {
-      "version": "2.11.5",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-gapcursor/-/extension-gapcursor-2.11.5.tgz",
-      "integrity": "sha512-kcWa+Xq9cb6lBdiICvLReuDtz/rLjFKHWpW3jTTF3FiP3wx4H8Rs6bzVtty7uOVTfwupxZRiKICAMEU6iT0xrQ==",
+      "version": "3.23.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-gapcursor/-/extension-gapcursor-3.23.4.tgz",
+      "integrity": "sha512-RuyvOlIGP6UpVOc0Lw0L63jKLtYM49CNhPV2OMSfwwwbBZ3pJGos2/SqpYg71d3sn+qpsAopS4Pfr8iPZog73A==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -911,14 +1064,13 @@
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.7.0",
-        "@tiptap/pm": "^2.7.0"
+        "@tiptap/extensions": "3.23.4"
       }
     },
     "node_modules/@tiptap/extension-hard-break": {
-      "version": "2.11.5",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-hard-break/-/extension-hard-break-2.11.5.tgz",
-      "integrity": "sha512-q9doeN+Yg9F5QNTG8pZGYfNye3tmntOwch683v0CCVCI4ldKaLZ0jG3NbBTq+mosHYdgOH2rNbIORlRRsQ+iYQ==",
+      "version": "3.23.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-hard-break/-/extension-hard-break-3.23.4.tgz",
+      "integrity": "sha512-ODlpZCi7n136BH9luM09EFL8Pg+bbRCd0tzCQM5BKMXRkLitYZA8Gl/f5DLmGJ50wzFsDPXK2Br2g9UvZK7COg==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -927,13 +1079,13 @@
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.7.0"
+        "@tiptap/core": "3.23.4"
       }
     },
     "node_modules/@tiptap/extension-heading": {
-      "version": "2.11.5",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-heading/-/extension-heading-2.11.5.tgz",
-      "integrity": "sha512-x/MV53psJ9baRcZ4k4WjnCUBMt8zCX7mPlKVT+9C/o+DEs/j/qxPLs95nHeQv70chZpSwCQCt93xMmuF0kPoAg==",
+      "version": "3.23.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-heading/-/extension-heading-3.23.4.tgz",
+      "integrity": "sha512-8W9Hqi0J69Xbqg08nPf4xRMJXMccaKFAgUE1tvy5PAWJSQxOMwkKQXgZXxwe+80sOMUnV8qveBqUy/ODMPgAxQ==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -942,29 +1094,13 @@
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.7.0"
-      }
-    },
-    "node_modules/@tiptap/extension-history": {
-      "version": "2.11.5",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-history/-/extension-history-2.11.5.tgz",
-      "integrity": "sha512-b+wOS33Dz1azw6F1i9LFTEIJ/gUui0Jwz5ZvmVDpL2ZHBhq1Ui0/spTT+tuZOXq7Y/uCbKL8Liu4WoedIvhboQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/ueberdosis"
-      },
-      "peerDependencies": {
-        "@tiptap/core": "^2.7.0",
-        "@tiptap/pm": "^2.7.0"
+        "@tiptap/core": "3.23.4"
       }
     },
     "node_modules/@tiptap/extension-horizontal-rule": {
-      "version": "2.11.5",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-horizontal-rule/-/extension-horizontal-rule-2.11.5.tgz",
-      "integrity": "sha512-3up2r1Du8/5/4ZYzTC0DjTwhgPI3dn8jhOCLu73m5F3OGvK/9whcXoeWoX103hYMnGDxBlfOje71yQuN35FL4A==",
+      "version": "3.23.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-horizontal-rule/-/extension-horizontal-rule-3.23.4.tgz",
+      "integrity": "sha512-EA4kK8ywZ4dQNOdxeZbplmDDs5T5LjMgHpqxRwukj9wwKiILOK5E3fcKm1fCKh9Q02w96jax6YVccHwmgJP3sQ==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -973,14 +1109,14 @@
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.7.0",
-        "@tiptap/pm": "^2.7.0"
+        "@tiptap/core": "3.23.4",
+        "@tiptap/pm": "3.23.4"
       }
     },
     "node_modules/@tiptap/extension-image": {
-      "version": "2.11.5",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-image/-/extension-image-2.11.5.tgz",
-      "integrity": "sha512-HbUq9AL8gb8eSuQfY/QKkvMc66ZFN/b6jvQAILGArNOgalUfGizoC6baKTJShaExMSPjBZlaAHtJiQKPaGRHaA==",
+      "version": "3.23.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-image/-/extension-image-3.23.4.tgz",
+      "integrity": "sha512-qandp5HLRl+n8D61+LCT67qtb1uSKffyEGD0fVTkg/RfbyFsJvCDFbjVEoiIG8JOx8O5DehgrDCvS35QOWgr2A==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -989,13 +1125,13 @@
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.7.0"
+        "@tiptap/core": "3.23.4"
       }
     },
     "node_modules/@tiptap/extension-italic": {
-      "version": "2.11.5",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-italic/-/extension-italic-2.11.5.tgz",
-      "integrity": "sha512-9VGfb2/LfPhQ6TjzDwuYLRvw0A6VGbaIp3F+5Mql8XVdTBHb2+rhELbyhNGiGVR78CaB/EiKb6dO9xu/tBWSYA==",
+      "version": "3.23.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-italic/-/extension-italic-3.23.4.tgz",
+      "integrity": "sha512-jUAHi+HZlg47BzgVIy6y/UH5vev7vPQ95jddhB5K3hC122kvWFMXlken7UOnqzbxNcHs2+4Oi/ZJirYMpT4P5w==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -1004,32 +1140,48 @@
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.7.0"
+        "@tiptap/core": "3.23.4"
       }
     },
     "node_modules/@tiptap/extension-link": {
-      "version": "2.11.5",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-link/-/extension-link-2.11.5.tgz",
-      "integrity": "sha512-4Iu/aPzevbYpe50xDI0ZkqRa6nkZ9eF270Ue2qaF3Ab47nehj+9Jl78XXzo8+LTyFMnrETI73TAs1aC/IGySeQ==",
+      "version": "3.23.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-link/-/extension-link-3.23.4.tgz",
+      "integrity": "sha512-XjxltY7MomwfTs6jmN6Bw5bb/upb34lpyqv2RiXppFTK25Br7ipksRjUpWpB4/csZeg30qwrLGVKxCol38ffrw==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "linkifyjs": "^4.2.0"
+        "linkifyjs": "^4.3.3"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.7.0",
-        "@tiptap/pm": "^2.7.0"
+        "@tiptap/core": "3.23.4",
+        "@tiptap/pm": "3.23.4"
+      }
+    },
+    "node_modules/@tiptap/extension-list": {
+      "version": "3.23.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-list/-/extension-list-3.23.4.tgz",
+      "integrity": "sha512-yuauDm6qW/7q+ZO0YJBKQEGdnUm6DDTJM8AMp9bMZrT4jRf/zyUtNcZ91QEfFvBcyVuI+10PIOXtNPevhQ741Q==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.23.4",
+        "@tiptap/pm": "3.23.4"
       }
     },
     "node_modules/@tiptap/extension-list-item": {
-      "version": "2.11.5",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-list-item/-/extension-list-item-2.11.5.tgz",
-      "integrity": "sha512-Mp5RD/pbkfW1vdc6xMVxXYcta73FOwLmblQlFNn/l/E5/X1DUSA4iGhgDDH4EWO3swbs03x2f7Zka/Xoj3+WLg==",
+      "version": "3.23.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-list-item/-/extension-list-item-3.23.4.tgz",
+      "integrity": "sha512-Q/JXosShD5oyDwukE6igdrZD2lb0ZgyoQTHYchk0pzU4frClFbn3RI1wKP+XeqKLhdO6KH2WZ9rERGH7PtDi7Q==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -1038,13 +1190,28 @@
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.7.0"
+        "@tiptap/extension-list": "3.23.4"
+      }
+    },
+    "node_modules/@tiptap/extension-list-keymap": {
+      "version": "3.23.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-list-keymap/-/extension-list-keymap-3.23.4.tgz",
+      "integrity": "sha512-9FezifCfuoc0o+5K6l4QNOOfelqxnDGg/f9oL1D/LFZPC54bPxpWWft9QCWOqyqZgyLCLjbCjciAlbgkrFUmmw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extension-list": "3.23.4"
       }
     },
     "node_modules/@tiptap/extension-ordered-list": {
-      "version": "2.11.5",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-ordered-list/-/extension-ordered-list-2.11.5.tgz",
-      "integrity": "sha512-Cu8KwruBNWAaEfshRQR0yOSaUKAeEwxW7UgbvF9cN/zZuKgK5uZosPCPTehIFCcRe+TBpRtZQh+06f/gNYpYYg==",
+      "version": "3.23.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-ordered-list/-/extension-ordered-list-3.23.4.tgz",
+      "integrity": "sha512-+3ofyssYnOTa1+nFWEmCAY1ngn8nAV1xo25JnNNC87NMU9WkSgr93jB7/uUJP0uui1C2dBLlaup3XXm108yarw==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -1053,13 +1220,13 @@
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.7.0"
+        "@tiptap/extension-list": "3.23.4"
       }
     },
     "node_modules/@tiptap/extension-paragraph": {
-      "version": "2.11.5",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-paragraph/-/extension-paragraph-2.11.5.tgz",
-      "integrity": "sha512-YFBWeg7xu/sBnsDIF/+nh9Arf7R0h07VZMd0id5Ydd2Qe3c1uIZwXxeINVtH0SZozuPIQFAT8ICe9M0RxmE+TA==",
+      "version": "3.23.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-paragraph/-/extension-paragraph-3.23.4.tgz",
+      "integrity": "sha512-KbhXjCFzWphvFn5VU7E4dtmYDm+bssI1i0+CnXPWCXkjdaaX88ck68Xp1fKz8/bbI/CqlgiNDO/3TvqgtZ6woQ==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -1068,29 +1235,13 @@
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.7.0"
-      }
-    },
-    "node_modules/@tiptap/extension-placeholder": {
-      "version": "2.11.5",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-placeholder/-/extension-placeholder-2.11.5.tgz",
-      "integrity": "sha512-Pr+0Ju/l2ZvXMd9VQxtaoSZbs0BBp1jbBDqwms88ctpyvQFRfLSfSkqudQcSHyw2ROOz2E31p/7I7fpI8Y0CLA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/ueberdosis"
-      },
-      "peerDependencies": {
-        "@tiptap/core": "^2.7.0",
-        "@tiptap/pm": "^2.7.0"
+        "@tiptap/core": "3.23.4"
       }
     },
     "node_modules/@tiptap/extension-strike": {
-      "version": "2.11.5",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-strike/-/extension-strike-2.11.5.tgz",
-      "integrity": "sha512-PVfUiCqrjvsLpbIoVlegSY8RlkR64F1Rr2RYmiybQfGbg+AkSZXDeO0eIrc03//4gua7D9DfIozHmAKv1KN3ow==",
+      "version": "3.23.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-strike/-/extension-strike-3.23.4.tgz",
+      "integrity": "sha512-Vnq5vW801zPbu1LtKeA5k4R241jY+hRjXeijYwIPxy15KzIiipY12518HiCf6/8kkRbMxgOfdYg9X4BRV3HV3g==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -1099,13 +1250,13 @@
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.7.0"
+        "@tiptap/core": "3.23.4"
       }
     },
     "node_modules/@tiptap/extension-subscript": {
-      "version": "2.11.5",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-subscript/-/extension-subscript-2.11.5.tgz",
-      "integrity": "sha512-VpaSzxku/Bcvf4SgDB2K5d0E+FNA/56iJHMygg/WXsq2F4tMMUEivQHI/n+17ndUEO4Wybz0wItnM1G2JfRuLQ==",
+      "version": "3.23.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-subscript/-/extension-subscript-3.23.4.tgz",
+      "integrity": "sha512-u0LXzexjXgbziQM5vl558us9WwXZgk++TAW1oHhcc/qj0W4+lke9ShGXRJmYk7Hd9mIk9hlbSEHVCWw5rf89bQ==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -1114,13 +1265,14 @@
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.7.0"
+        "@tiptap/core": "3.23.4",
+        "@tiptap/pm": "3.23.4"
       }
     },
     "node_modules/@tiptap/extension-superscript": {
-      "version": "2.11.5",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-superscript/-/extension-superscript-2.11.5.tgz",
-      "integrity": "sha512-sK6v2G0zFfGW+j9CmYp2e+tyZ3FTa3dP0xY4kJzefgZcHhMJLlLnjxBRwHCSi/jj5ie6WdZT4KoEooxnPs1Vzw==",
+      "version": "3.23.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-superscript/-/extension-superscript-3.23.4.tgz",
+      "integrity": "sha512-ayi0zVlslpkQ5ynild6rvvU1ZDcW6/CJSpNFr2RqlARPgYWIqtytWSyNDvDFcrTu7n+07HN8bCwLY9xkVZC50g==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -1129,13 +1281,14 @@
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.7.0"
+        "@tiptap/core": "3.23.4",
+        "@tiptap/pm": "3.23.4"
       }
     },
     "node_modules/@tiptap/extension-table": {
-      "version": "2.11.5",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-table/-/extension-table-2.11.5.tgz",
-      "integrity": "sha512-NKXLhKWdAdURklm98YkCd2ai4fh8jY8HS/+X2s/2QiQt8Z98CU1keCm35fJEEExM234iB/hCqG5vY4JgTc0Tvw==",
+      "version": "3.23.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-table/-/extension-table-3.23.4.tgz",
+      "integrity": "sha512-TRh6JMTRYXCWpwavGt3aAHH2f51ZzkhurfW3XvrURG3It8MvfuuY1xB1xba1ss5c0QLWlrKx6GVaSXrUCdFLlg==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -1144,59 +1297,14 @@
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.7.0",
-        "@tiptap/pm": "^2.7.0"
-      }
-    },
-    "node_modules/@tiptap/extension-table-cell": {
-      "version": "2.11.5",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-table-cell/-/extension-table-cell-2.11.5.tgz",
-      "integrity": "sha512-S967Au0pgeULstP3FaasOf/LEh72p61Ooh1PcUMF/az4x8EeGgpcEUARpVUxsGxLFvogv6LmhPHZdtcGgdHcBw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/ueberdosis"
-      },
-      "peerDependencies": {
-        "@tiptap/core": "^2.7.0"
-      }
-    },
-    "node_modules/@tiptap/extension-table-header": {
-      "version": "2.11.5",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-table-header/-/extension-table-header-2.11.5.tgz",
-      "integrity": "sha512-O1iBtzZP1XZDi4h1Xmgq1T63il+fpKPvBIMZ0JJH9TyCw5i5rcrMLL2dyy5zaWK3BFRJuYBNSke4c+VWnr/g6w==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/ueberdosis"
-      },
-      "peerDependencies": {
-        "@tiptap/core": "^2.7.0"
-      }
-    },
-    "node_modules/@tiptap/extension-table-row": {
-      "version": "2.11.5",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-table-row/-/extension-table-row-2.11.5.tgz",
-      "integrity": "sha512-+/VWhCuW24BcM5aaIc/f0bC6ZR1Q5gnuqw13MIo7gyPx7iIY6BXK8roGiZSs8wYAN4uBEf3EKFm0bSZwQuAeyg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/ueberdosis"
-      },
-      "peerDependencies": {
-        "@tiptap/core": "^2.7.0"
+        "@tiptap/core": "3.23.4",
+        "@tiptap/pm": "3.23.4"
       }
     },
     "node_modules/@tiptap/extension-text": {
-      "version": "2.11.5",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-text/-/extension-text-2.11.5.tgz",
-      "integrity": "sha512-Gq1WwyhFpCbEDrLPIHt5A8aLSlf8bfz4jm417c8F/JyU0J5dtYdmx0RAxjnLw1i7ZHE7LRyqqAoS0sl7JHDNSQ==",
+      "version": "3.23.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-text/-/extension-text-3.23.4.tgz",
+      "integrity": "sha512-q9kxver/MR18p66aWZHSPycnr9hcBFyVGeGj8gf+BQCzn5hpvtSYTfLvk1nq8GFhygdQ9/e3f7B5ovrm/jnpvw==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -1205,13 +1313,13 @@
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.7.0"
+        "@tiptap/core": "3.23.4"
       }
     },
     "node_modules/@tiptap/extension-text-align": {
-      "version": "2.11.5",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-text-align/-/extension-text-align-2.11.5.tgz",
-      "integrity": "sha512-Ei0zDpH5N9EV59ogydK4HTKa4lCPicCsQllM5n/Nf2tUJPir3aiYxzJ73FzhComD4Hpo1ANYnmssBhy8QeoPZA==",
+      "version": "3.23.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-text-align/-/extension-text-align-3.23.4.tgz",
+      "integrity": "sha512-A3WVhAs6YFlkfa7hNgps21QLfitNZyWFBBepQusX35sz6BlaHSy9GVrTR/JjGwGIxhNoqU2SGApvf2xTuX89gQ==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -1220,13 +1328,13 @@
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.7.0"
+        "@tiptap/core": "3.23.4"
       }
     },
     "node_modules/@tiptap/extension-text-style": {
-      "version": "2.11.5",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-text-style/-/extension-text-style-2.11.5.tgz",
-      "integrity": "sha512-YUmYl0gILSd/u/ZkOmNxjNXVw+mu8fpC2f8G4I4tLODm0zCx09j9DDEJXSrM5XX72nxJQqtSQsCpNKnL0hfeEQ==",
+      "version": "3.23.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-text-style/-/extension-text-style-3.23.4.tgz",
+      "integrity": "sha512-jb9PBkvqqn14ju37VMYOmmva9t9Th7vutoio9iB7etcu4XhL/4Z8rYPZmO+9+HLros2TQ/1JeCNZzc8LzcuBiA==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -1235,13 +1343,13 @@
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.7.0"
+        "@tiptap/core": "3.23.4"
       }
     },
     "node_modules/@tiptap/extension-underline": {
-      "version": "2.11.5",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-underline/-/extension-underline-2.11.5.tgz",
-      "integrity": "sha512-YpWHXNIkSoRSuzT2cvgKpyJ2tTz3LzqkTM64uC+uTJ8cUkvXIWUWejJR42q8ma/mTlQe4lHff4IQ0Sf58Digtw==",
+      "version": "3.23.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-underline/-/extension-underline-3.23.4.tgz",
+      "integrity": "sha512-F1ocPT10LV+seky25R1TMCRdc/Iof99jLcDSYDGr6mNEDY4ct2RvOeSM8aDdYq6CkH+vXt3i3JDeRwV23KzswQ==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -1250,35 +1358,45 @@
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^2.7.0"
+        "@tiptap/core": "3.23.4"
+      }
+    },
+    "node_modules/@tiptap/extensions": {
+      "version": "3.23.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/extensions/-/extensions-3.23.4.tgz",
+      "integrity": "sha512-SlGPXauW8iKWG7wwuwC/0y/smLImp0h6GBIGgNnTBgIP/ThXQnjLMSZH0mW/REO87dQxkku01V3ARRywi+juhg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.23.4",
+        "@tiptap/pm": "3.23.4"
       }
     },
     "node_modules/@tiptap/pm": {
-      "version": "2.11.5",
-      "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-2.11.5.tgz",
-      "integrity": "sha512-z9JFtqc5ZOsdQLd9vRnXfTCQ8v5ADAfRt9Nm7SqP6FUHII8E1hs38ACzf5xursmth/VonJYb5+73Pqxk1hGIPw==",
+      "version": "3.23.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-3.23.4.tgz",
+      "integrity": "sha512-+C5ngcoza47n3MjtjVBqBEBICPC0McdbwzJ+X6SSCviCLoqnSYanv5mIX9HWG0Q4fJ4BkdNM3VibZUxQaTbKyQ==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "prosemirror-changeset": "^2.2.1",
-        "prosemirror-collab": "^1.3.1",
+        "prosemirror-changeset": "^2.3.0",
         "prosemirror-commands": "^1.6.2",
         "prosemirror-dropcursor": "^1.8.1",
         "prosemirror-gapcursor": "^1.3.2",
         "prosemirror-history": "^1.4.1",
-        "prosemirror-inputrules": "^1.4.0",
         "prosemirror-keymap": "^1.2.2",
-        "prosemirror-markdown": "^1.13.1",
-        "prosemirror-menu": "^1.2.4",
-        "prosemirror-model": "^1.23.0",
-        "prosemirror-schema-basic": "^1.2.3",
-        "prosemirror-schema-list": "^1.4.1",
+        "prosemirror-model": "^1.24.1",
+        "prosemirror-schema-list": "^1.5.0",
         "prosemirror-state": "^1.4.3",
-        "prosemirror-tables": "^1.6.3",
-        "prosemirror-trailing-node": "^3.0.0",
+        "prosemirror-tables": "^1.6.4",
         "prosemirror-transform": "^1.10.2",
-        "prosemirror-view": "^1.37.0"
+        "prosemirror-view": "^1.38.1"
       },
       "funding": {
         "type": "github",
@@ -1286,34 +1404,37 @@
       }
     },
     "node_modules/@tiptap/starter-kit": {
-      "version": "2.11.5",
-      "resolved": "https://registry.npmjs.org/@tiptap/starter-kit/-/starter-kit-2.11.5.tgz",
-      "integrity": "sha512-SLI7Aj2ruU1t//6Mk8f+fqW+18uTqpdfLUJYgwu0CkqBckrkRZYZh6GVLk/02k3H2ki7QkFxiFbZrdbZdng0JA==",
+      "version": "3.23.4",
+      "resolved": "https://registry.npmjs.org/@tiptap/starter-kit/-/starter-kit-3.23.4.tgz",
+      "integrity": "sha512-3VhU+NO6/ec9DMj/5Ej0nzARSq42cXnqW+QHCmTL3FNXkXQz+tw1KlfruT5GGJ3M0RssjWjRC0a39N/4S3qxeA==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@tiptap/core": "^2.11.5",
-        "@tiptap/extension-blockquote": "^2.11.5",
-        "@tiptap/extension-bold": "^2.11.5",
-        "@tiptap/extension-bullet-list": "^2.11.5",
-        "@tiptap/extension-code": "^2.11.5",
-        "@tiptap/extension-code-block": "^2.11.5",
-        "@tiptap/extension-document": "^2.11.5",
-        "@tiptap/extension-dropcursor": "^2.11.5",
-        "@tiptap/extension-gapcursor": "^2.11.5",
-        "@tiptap/extension-hard-break": "^2.11.5",
-        "@tiptap/extension-heading": "^2.11.5",
-        "@tiptap/extension-history": "^2.11.5",
-        "@tiptap/extension-horizontal-rule": "^2.11.5",
-        "@tiptap/extension-italic": "^2.11.5",
-        "@tiptap/extension-list-item": "^2.11.5",
-        "@tiptap/extension-ordered-list": "^2.11.5",
-        "@tiptap/extension-paragraph": "^2.11.5",
-        "@tiptap/extension-strike": "^2.11.5",
-        "@tiptap/extension-text": "^2.11.5",
-        "@tiptap/extension-text-style": "^2.11.5",
-        "@tiptap/pm": "^2.11.5"
+        "@tiptap/core": "^3.23.4",
+        "@tiptap/extension-blockquote": "^3.23.4",
+        "@tiptap/extension-bold": "^3.23.4",
+        "@tiptap/extension-bullet-list": "^3.23.4",
+        "@tiptap/extension-code": "^3.23.4",
+        "@tiptap/extension-code-block": "^3.23.4",
+        "@tiptap/extension-document": "^3.23.4",
+        "@tiptap/extension-dropcursor": "^3.23.4",
+        "@tiptap/extension-gapcursor": "^3.23.4",
+        "@tiptap/extension-hard-break": "^3.23.4",
+        "@tiptap/extension-heading": "^3.23.4",
+        "@tiptap/extension-horizontal-rule": "^3.23.4",
+        "@tiptap/extension-italic": "^3.23.4",
+        "@tiptap/extension-link": "^3.23.4",
+        "@tiptap/extension-list": "^3.23.4",
+        "@tiptap/extension-list-item": "^3.23.4",
+        "@tiptap/extension-list-keymap": "^3.23.4",
+        "@tiptap/extension-ordered-list": "^3.23.4",
+        "@tiptap/extension-paragraph": "^3.23.4",
+        "@tiptap/extension-strike": "^3.23.4",
+        "@tiptap/extension-text": "^3.23.4",
+        "@tiptap/extension-underline": "^3.23.4",
+        "@tiptap/extensions": "^3.23.4",
+        "@tiptap/pm": "^3.23.4"
       },
       "funding": {
         "type": "github",
@@ -1321,9 +1442,9 @@
       }
     },
     "node_modules/@types/diff": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/@types/diff/-/diff-7.0.1.tgz",
-      "integrity": "sha512-R/BHQFripuhW6XPXy05hIvXJQdQ4540KnTvEFHSLjXfHYM41liOLKgIJEyYYiQe796xpaMHfe4Uj/p7Uvng2vA==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@types/diff/-/diff-7.0.2.tgz",
+      "integrity": "sha512-JSWRMozjFKsGlEjiiKajUjIJVKuKdE3oVy2DNtK+fUo8q82nhFZ2CPQwicAIkXrofahDXrWJ7mjelvZphMS98Q==",
       "dev": true,
       "license": "MIT",
       "peer": true
@@ -1335,30 +1456,10 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/linkify-it": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-5.0.0.tgz",
-      "integrity": "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/@types/markdown-it": {
-      "version": "14.1.2",
-      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.1.2.tgz",
-      "integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@types/linkify-it": "^5",
-        "@types/mdurl": "^2"
-      }
-    },
-    "node_modules/@types/mdurl": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-2.0.0.tgz",
-      "integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
       "license": "MIT",
       "peer": true
@@ -1382,190 +1483,186 @@
       "peer": true
     },
     "node_modules/@umbraco-cms/backoffice": {
-      "version": "15.3.1",
-      "resolved": "https://registry.npmjs.org/@umbraco-cms/backoffice/-/backoffice-15.3.1.tgz",
-      "integrity": "sha512-Vp1ckRjyNCOSj2le6OjH5V3MUTAzI3+ecp28Ep9o7QOayj7cW4VwflkbQHnUnYTRWh4b10wJpY3TlajaxH0g8Q==",
+      "version": "17.4.0",
+      "resolved": "https://registry.npmjs.org/@umbraco-cms/backoffice/-/backoffice-17.4.0.tgz",
+      "integrity": "sha512-BLGxXwVyi1KiBmBwytxvXd9gS6xvSau0X1P1GdwWh6JEYc/fBuLF49T4+wHpLmlLoc2eR396E4Ha1rvdbms0eg==",
       "dev": true,
       "license": "MIT",
-      "workspaces": [
-        "./src/packages/*"
-      ],
       "engines": {
-        "node": ">=22",
-        "npm": ">=10.9"
+        "node": ">=22.17.1",
+        "npm": ">=10.9.2"
       },
       "peerDependencies": {
-        "@tiptap/core": "2.11.5",
-        "@tiptap/extension-image": "2.11.5",
-        "@tiptap/extension-link": "2.11.5",
-        "@tiptap/extension-placeholder": "2.11.5",
-        "@tiptap/extension-subscript": "2.11.5",
-        "@tiptap/extension-superscript": "2.11.5",
-        "@tiptap/extension-table": "2.11.5",
-        "@tiptap/extension-table-cell": "2.11.5",
-        "@tiptap/extension-table-header": "2.11.5",
-        "@tiptap/extension-table-row": "2.11.5",
-        "@tiptap/extension-text-align": "2.11.5",
-        "@tiptap/extension-underline": "2.11.5",
-        "@tiptap/pm": "2.11.5",
-        "@tiptap/starter-kit": "2.11.5",
-        "@types/diff": "^7.0.1",
-        "@umbraco-ui/uui": "^1.12.2",
-        "@umbraco-ui/uui-css": "^1.12.1",
-        "diff": "^7.0.0",
-        "dompurify": "^3.2.4",
-        "element-internals-polyfill": "^1.3.13",
-        "lit": "^3.2.1",
-        "marked": "^15.0.7",
-        "monaco-editor": "^0.52.2",
-        "rxjs": "^7.8.1",
-        "tinymce": "^6.8.5",
-        "tinymce-i18n": "^24.12.30",
-        "uuid": "^11.0.5"
+        "@heximal/expressions": ">=0.1.5 <1.0.0",
+        "@hey-api/openapi-ts": ">=0.85.2 <1.0.0",
+        "@microsoft/signalr": "^10.0.0",
+        "@tiptap/core": "^3.22.3",
+        "@tiptap/extension-image": "^3.22.3",
+        "@tiptap/extension-subscript": "^3.22.3",
+        "@tiptap/extension-superscript": "^3.22.3",
+        "@tiptap/extension-table": "^3.22.3",
+        "@tiptap/extension-text-align": "^3.22.3",
+        "@tiptap/extension-text-style": "^3.22.3",
+        "@tiptap/extensions": "^3.22.3",
+        "@tiptap/pm": "^3.22.3",
+        "@tiptap/starter-kit": "^3.22.3",
+        "@types/diff": "^7.0.2",
+        "@umbraco-ui/uui": "^1.17.3",
+        "@umbraco-ui/uui-css": "^1.17.3",
+        "diff": "^9.0.0",
+        "dompurify": "^3.4.0",
+        "element-internals-polyfill": "^3.0.2",
+        "lit": "^3.3.1",
+        "luxon": "^3.7.2",
+        "marked": "^18.0.0",
+        "monaco-editor": ">=0.55.1 <1.0.0",
+        "rxjs": "^7.8.2",
+        "uuid": "^13.0.0"
       }
     },
     "node_modules/@umbraco-ui/uui": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui/-/uui-1.12.2.tgz",
-      "integrity": "sha512-oEqt0ysOpqlpMk7AOX+88aV0dgnHfSXxE6imJw0KQKNMnZNOKv7EpndGliLJW/N2hgXQoVPESeYAfbLLt8J0MQ==",
+      "version": "1.17.3",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui/-/uui-1.17.3.tgz",
+      "integrity": "sha512-cMXJlqXexfZvasAiWKLbVkUnZ5PA/fRH/0SGtnp3aiSAdTZqCqNg9qjygX9GPN9PczJlRyBB/Y1mp50p27cQqw==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-action-bar": "1.12.2",
-        "@umbraco-ui/uui-avatar": "1.12.2",
-        "@umbraco-ui/uui-avatar-group": "1.12.2",
-        "@umbraco-ui/uui-badge": "1.12.2",
-        "@umbraco-ui/uui-base": "1.12.2",
-        "@umbraco-ui/uui-boolean-input": "1.12.2",
-        "@umbraco-ui/uui-box": "1.12.2",
-        "@umbraco-ui/uui-breadcrumbs": "1.12.2",
-        "@umbraco-ui/uui-button": "1.12.2",
-        "@umbraco-ui/uui-button-group": "1.12.2",
-        "@umbraco-ui/uui-button-inline-create": "1.12.2",
-        "@umbraco-ui/uui-card": "1.12.2",
-        "@umbraco-ui/uui-card-block-type": "1.12.2",
-        "@umbraco-ui/uui-card-content-node": "1.12.2",
-        "@umbraco-ui/uui-card-media": "1.12.2",
-        "@umbraco-ui/uui-card-user": "1.12.2",
-        "@umbraco-ui/uui-caret": "1.12.2",
-        "@umbraco-ui/uui-checkbox": "1.12.2",
-        "@umbraco-ui/uui-color-area": "1.12.2",
-        "@umbraco-ui/uui-color-picker": "1.12.2",
-        "@umbraco-ui/uui-color-slider": "1.12.2",
-        "@umbraco-ui/uui-color-swatch": "1.12.2",
-        "@umbraco-ui/uui-color-swatches": "1.12.2",
-        "@umbraco-ui/uui-combobox": "1.12.2",
-        "@umbraco-ui/uui-combobox-list": "1.12.2",
-        "@umbraco-ui/uui-css": "1.12.1",
-        "@umbraco-ui/uui-dialog": "1.12.2",
-        "@umbraco-ui/uui-dialog-layout": "1.12.2",
-        "@umbraco-ui/uui-file-dropzone": "1.12.2",
-        "@umbraco-ui/uui-file-preview": "1.12.2",
-        "@umbraco-ui/uui-form": "1.12.2",
-        "@umbraco-ui/uui-form-layout-item": "1.12.2",
-        "@umbraco-ui/uui-form-validation-message": "1.12.2",
-        "@umbraco-ui/uui-icon": "1.12.2",
-        "@umbraco-ui/uui-icon-registry": "1.12.2",
-        "@umbraco-ui/uui-icon-registry-essential": "1.12.2",
-        "@umbraco-ui/uui-input": "1.12.2",
-        "@umbraco-ui/uui-input-file": "1.12.2",
-        "@umbraco-ui/uui-input-lock": "1.12.2",
-        "@umbraco-ui/uui-input-password": "1.12.2",
-        "@umbraco-ui/uui-keyboard-shortcut": "1.12.2",
-        "@umbraco-ui/uui-label": "1.12.2",
-        "@umbraco-ui/uui-loader": "1.12.2",
-        "@umbraco-ui/uui-loader-bar": "1.12.2",
-        "@umbraco-ui/uui-loader-circle": "1.12.2",
-        "@umbraco-ui/uui-menu-item": "1.12.2",
-        "@umbraco-ui/uui-modal": "1.12.2",
-        "@umbraco-ui/uui-pagination": "1.12.2",
-        "@umbraco-ui/uui-popover": "1.12.2",
-        "@umbraco-ui/uui-popover-container": "1.12.2",
-        "@umbraco-ui/uui-progress-bar": "1.12.2",
-        "@umbraco-ui/uui-radio": "1.12.2",
-        "@umbraco-ui/uui-range-slider": "1.12.2",
-        "@umbraco-ui/uui-ref": "1.12.2",
-        "@umbraco-ui/uui-ref-list": "1.12.2",
-        "@umbraco-ui/uui-ref-node": "1.12.2",
-        "@umbraco-ui/uui-ref-node-data-type": "1.12.2",
-        "@umbraco-ui/uui-ref-node-document-type": "1.12.2",
-        "@umbraco-ui/uui-ref-node-form": "1.12.2",
-        "@umbraco-ui/uui-ref-node-member": "1.12.2",
-        "@umbraco-ui/uui-ref-node-package": "1.12.2",
-        "@umbraco-ui/uui-ref-node-user": "1.12.2",
-        "@umbraco-ui/uui-scroll-container": "1.12.2",
-        "@umbraco-ui/uui-select": "1.12.2",
-        "@umbraco-ui/uui-slider": "1.12.2",
-        "@umbraco-ui/uui-symbol-expand": "1.12.2",
-        "@umbraco-ui/uui-symbol-file": "1.12.2",
-        "@umbraco-ui/uui-symbol-file-dropzone": "1.12.2",
-        "@umbraco-ui/uui-symbol-file-thumbnail": "1.12.2",
-        "@umbraco-ui/uui-symbol-folder": "1.12.2",
-        "@umbraco-ui/uui-symbol-lock": "1.12.2",
-        "@umbraco-ui/uui-symbol-more": "1.12.2",
-        "@umbraco-ui/uui-symbol-sort": "1.12.2",
-        "@umbraco-ui/uui-table": "1.12.2",
-        "@umbraco-ui/uui-tabs": "1.12.2",
-        "@umbraco-ui/uui-tag": "1.12.2",
-        "@umbraco-ui/uui-textarea": "1.12.2",
-        "@umbraco-ui/uui-toast-notification": "1.12.2",
-        "@umbraco-ui/uui-toast-notification-container": "1.12.2",
-        "@umbraco-ui/uui-toast-notification-layout": "1.12.2",
-        "@umbraco-ui/uui-toggle": "1.12.2",
-        "@umbraco-ui/uui-visually-hidden": "1.12.2"
+        "@umbraco-ui/uui-action-bar": "1.17.3",
+        "@umbraco-ui/uui-avatar": "1.17.3",
+        "@umbraco-ui/uui-avatar-group": "1.17.3",
+        "@umbraco-ui/uui-badge": "1.17.3",
+        "@umbraco-ui/uui-base": "1.17.3",
+        "@umbraco-ui/uui-boolean-input": "1.17.3",
+        "@umbraco-ui/uui-box": "1.17.3",
+        "@umbraco-ui/uui-breadcrumbs": "1.17.3",
+        "@umbraco-ui/uui-button": "1.17.3",
+        "@umbraco-ui/uui-button-copy-text": "1.17.3",
+        "@umbraco-ui/uui-button-group": "1.17.3",
+        "@umbraco-ui/uui-button-inline-create": "1.17.3",
+        "@umbraco-ui/uui-card": "1.17.3",
+        "@umbraco-ui/uui-card-block-type": "1.17.3",
+        "@umbraco-ui/uui-card-content-node": "1.17.3",
+        "@umbraco-ui/uui-card-media": "1.17.3",
+        "@umbraco-ui/uui-card-user": "1.17.3",
+        "@umbraco-ui/uui-caret": "1.17.3",
+        "@umbraco-ui/uui-checkbox": "1.17.3",
+        "@umbraco-ui/uui-color-area": "1.17.3",
+        "@umbraco-ui/uui-color-picker": "1.17.3",
+        "@umbraco-ui/uui-color-slider": "1.17.3",
+        "@umbraco-ui/uui-color-swatch": "1.17.3",
+        "@umbraco-ui/uui-color-swatches": "1.17.3",
+        "@umbraco-ui/uui-combobox": "1.17.3",
+        "@umbraco-ui/uui-combobox-list": "1.17.3",
+        "@umbraco-ui/uui-css": "1.17.3",
+        "@umbraco-ui/uui-dialog": "1.17.3",
+        "@umbraco-ui/uui-dialog-layout": "1.17.3",
+        "@umbraco-ui/uui-file-dropzone": "1.17.3",
+        "@umbraco-ui/uui-file-preview": "1.17.3",
+        "@umbraco-ui/uui-form": "1.17.3",
+        "@umbraco-ui/uui-form-layout-item": "1.17.3",
+        "@umbraco-ui/uui-form-validation-message": "1.17.3",
+        "@umbraco-ui/uui-icon": "1.17.3",
+        "@umbraco-ui/uui-icon-registry": "1.17.3",
+        "@umbraco-ui/uui-icon-registry-essential": "1.17.3",
+        "@umbraco-ui/uui-input": "1.17.3",
+        "@umbraco-ui/uui-input-file": "1.17.3",
+        "@umbraco-ui/uui-input-lock": "1.17.3",
+        "@umbraco-ui/uui-input-password": "1.17.3",
+        "@umbraco-ui/uui-keyboard-shortcut": "1.17.3",
+        "@umbraco-ui/uui-label": "1.17.3",
+        "@umbraco-ui/uui-loader": "1.17.3",
+        "@umbraco-ui/uui-loader-bar": "1.17.3",
+        "@umbraco-ui/uui-loader-circle": "1.17.3",
+        "@umbraco-ui/uui-menu-item": "1.17.3",
+        "@umbraco-ui/uui-modal": "1.17.3",
+        "@umbraco-ui/uui-pagination": "1.17.3",
+        "@umbraco-ui/uui-popover": "1.17.3",
+        "@umbraco-ui/uui-popover-container": "1.17.3",
+        "@umbraco-ui/uui-progress-bar": "1.17.3",
+        "@umbraco-ui/uui-radio": "1.17.3",
+        "@umbraco-ui/uui-range-slider": "1.17.3",
+        "@umbraco-ui/uui-ref": "1.17.3",
+        "@umbraco-ui/uui-ref-list": "1.17.3",
+        "@umbraco-ui/uui-ref-node": "1.17.3",
+        "@umbraco-ui/uui-ref-node-data-type": "1.17.3",
+        "@umbraco-ui/uui-ref-node-document-type": "1.17.3",
+        "@umbraco-ui/uui-ref-node-form": "1.17.3",
+        "@umbraco-ui/uui-ref-node-member": "1.17.3",
+        "@umbraco-ui/uui-ref-node-package": "1.17.3",
+        "@umbraco-ui/uui-ref-node-user": "1.17.3",
+        "@umbraco-ui/uui-scroll-container": "1.17.3",
+        "@umbraco-ui/uui-select": "1.17.3",
+        "@umbraco-ui/uui-slider": "1.17.3",
+        "@umbraco-ui/uui-symbol-expand": "1.17.3",
+        "@umbraco-ui/uui-symbol-file": "1.17.3",
+        "@umbraco-ui/uui-symbol-file-dropzone": "1.17.3",
+        "@umbraco-ui/uui-symbol-file-thumbnail": "1.17.3",
+        "@umbraco-ui/uui-symbol-folder": "1.17.3",
+        "@umbraco-ui/uui-symbol-lock": "1.17.3",
+        "@umbraco-ui/uui-symbol-more": "1.17.3",
+        "@umbraco-ui/uui-symbol-sort": "1.17.3",
+        "@umbraco-ui/uui-table": "1.17.3",
+        "@umbraco-ui/uui-tabs": "1.17.3",
+        "@umbraco-ui/uui-tag": "1.17.3",
+        "@umbraco-ui/uui-textarea": "1.17.3",
+        "@umbraco-ui/uui-toast-notification": "1.17.3",
+        "@umbraco-ui/uui-toast-notification-container": "1.17.3",
+        "@umbraco-ui/uui-toast-notification-layout": "1.17.3",
+        "@umbraco-ui/uui-toggle": "1.17.3",
+        "@umbraco-ui/uui-visually-hidden": "1.17.3"
       }
     },
     "node_modules/@umbraco-ui/uui-action-bar": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-action-bar/-/uui-action-bar-1.12.2.tgz",
-      "integrity": "sha512-ZWTO7//oKxo5vpA+RypyxpfVMPi5f8f1uevbJ8PMdizDi67VxN1kxYA4geMzG8OQ+x5IGp01DCTtVeAx3qoJbg==",
+      "version": "1.17.3",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-action-bar/-/uui-action-bar-1.17.3.tgz",
+      "integrity": "sha512-d4B/SvhSEEOooYffEfKbfNBATviFKQ21OM+CApz5GGE49jHqpl4jVoVfum2YWiqQexNtRNQEckGCHUg2OZlLJg==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.12.2",
-        "@umbraco-ui/uui-button-group": "1.12.2"
+        "@umbraco-ui/uui-base": "1.17.3",
+        "@umbraco-ui/uui-button-group": "1.17.3"
       }
     },
     "node_modules/@umbraco-ui/uui-avatar": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-avatar/-/uui-avatar-1.12.2.tgz",
-      "integrity": "sha512-b/TkEIGJoouqCZLIBl/c0veJg8imImd35Ed+R1VPlcHFXrgpO8C54Fr0AEwsM5x5OeTtkfvs/18pveLPucraww==",
+      "version": "1.17.3",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-avatar/-/uui-avatar-1.17.3.tgz",
+      "integrity": "sha512-peTFJuk/c10NAD7oP2k8PkvdYzmBNVvrHmmhAOs0LBdrgRMCqstLqDABi17XH0MHYZEf1n8Z/DjnTCOBw9Tchw==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.12.2"
+        "@umbraco-ui/uui-base": "1.17.3"
       }
     },
     "node_modules/@umbraco-ui/uui-avatar-group": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-avatar-group/-/uui-avatar-group-1.12.2.tgz",
-      "integrity": "sha512-QdymxxxC6qCRAu8vAM7Owgbe/ubZ+BL+wu0qk8RXz77CVORgLpiFeUM4YwOapOXvtogXR6haxf8m3/7nxedqdg==",
+      "version": "1.17.3",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-avatar-group/-/uui-avatar-group-1.17.3.tgz",
+      "integrity": "sha512-+6kslm21rzqXVYMd1l07gW3k00+YGAufEOSQMxn5HAUnqq9dZu0X70LInx+pOZhEBsBakbv/zgAU9Wa36Rl38Q==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-avatar": "1.12.2",
-        "@umbraco-ui/uui-base": "1.12.2"
+        "@umbraco-ui/uui-avatar": "1.17.3",
+        "@umbraco-ui/uui-base": "1.17.3"
       }
     },
     "node_modules/@umbraco-ui/uui-badge": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-badge/-/uui-badge-1.12.2.tgz",
-      "integrity": "sha512-jkD8rHvunbUDNZfDCekuP5DI23ufBZD+8Y3FHv5aLOAbRm9XrbJ0B4QHyKQoglQ2Yao6iKeYq+nxzG2x88Z7Dw==",
+      "version": "1.17.3",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-badge/-/uui-badge-1.17.3.tgz",
+      "integrity": "sha512-Y9TcBSDHpcgq1zOf54KmXCnIKst6tG4KVKGAIcPllwFnkfmmaS+AFIWojXAM/1REF9BMsqw4tuSFiGg8HbwmsQ==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.12.2"
+        "@umbraco-ui/uui-base": "1.17.3"
       }
     },
     "node_modules/@umbraco-ui/uui-base": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-base/-/uui-base-1.12.2.tgz",
-      "integrity": "sha512-EyPrP28teYlGeeTZvmq+4wzP8Gh9A963HbZ1nQ3oyGj+twN6QjEKUF7W4VVZ8RvFoyS1/6bWkRODuZAzAwX31g==",
+      "version": "1.17.3",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-base/-/uui-base-1.17.3.tgz",
+      "integrity": "sha512-K8UtW39qE4rqfaZF5/oxi58cdaweCXPbda+Yl1MyPjJjesxpvh1TOXbsmol1WzOq/S2Atnr+uOMp5Ogc+p0VBg==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -1574,253 +1671,267 @@
       }
     },
     "node_modules/@umbraco-ui/uui-boolean-input": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-boolean-input/-/uui-boolean-input-1.12.2.tgz",
-      "integrity": "sha512-/NGwAPgXLiaDIMwunTDth21jQ0+5ajH3gJ5JJH6IGIq+N2g7babAEKybkZybYq+mxH//7ljH/uKDHI9IztW58g==",
+      "version": "1.17.3",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-boolean-input/-/uui-boolean-input-1.17.3.tgz",
+      "integrity": "sha512-D798gTVjokjcFqL4dnYVW431mRp5xjxsY8cCgc4lBW/xpS1T56+rF0jZdCBamrraCEkGB5KXF1wPuJsK+knIsA==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.12.2"
+        "@umbraco-ui/uui-base": "1.17.3"
       }
     },
     "node_modules/@umbraco-ui/uui-box": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-box/-/uui-box-1.12.2.tgz",
-      "integrity": "sha512-JUxqsRjqUbZ5NM5S1w40NUlHUHPIcMFqYTeCq+nLHE9WSLchym3NN+0NZjS2+qpO70kYPGlKf39mahy+rbGP9Q==",
+      "version": "1.17.3",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-box/-/uui-box-1.17.3.tgz",
+      "integrity": "sha512-dJ0Nl4ao08MiEwsjcixIbxSvB/O+/52nnK8EQ+tNBQbCFb5sAzhGIySlDmLe8rLHUhvjgHzVXDIWWOtKd4myYw==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.12.2",
-        "@umbraco-ui/uui-css": "1.12.1"
+        "@umbraco-ui/uui-base": "1.17.3",
+        "@umbraco-ui/uui-css": "1.17.3"
       }
     },
     "node_modules/@umbraco-ui/uui-breadcrumbs": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-breadcrumbs/-/uui-breadcrumbs-1.12.2.tgz",
-      "integrity": "sha512-P/L4q5whw1/HVMMUmzgq5CYOu3ZoLmtlTUoOnTXj+g5R0ziX5ikjJWF1JnLa6M7ES43aB/7su9GeyvOMkcxMpA==",
+      "version": "1.17.3",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-breadcrumbs/-/uui-breadcrumbs-1.17.3.tgz",
+      "integrity": "sha512-9DtncHwG+gy4eIGV2kAiA6Nhcpf7rsIvtME8ECBpwgVd1j46dByNFuNJidHEIMJ+i4yAwIRplkw/ybKI55ZPOg==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.12.2"
+        "@umbraco-ui/uui-base": "1.17.3",
+        "@umbraco-ui/uui-responsive-container": "1.17.3"
       }
     },
     "node_modules/@umbraco-ui/uui-button": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-button/-/uui-button-1.12.2.tgz",
-      "integrity": "sha512-x3zF+GLwfpc6W2vB3xLRX6g+hdKdEWMKLXtfl+WPOkocu8+EYzodrUHQg24/lO43j7ovy8c3t+zN8OhjnZMu2Q==",
+      "version": "1.17.3",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-button/-/uui-button-1.17.3.tgz",
+      "integrity": "sha512-DbjPjZ+iOMucFJ4nok8+pyL9REXx256tNU8ELaZ7B0daOaTA9WF/dxbtj2GPbR9P1unIv5hlzm3gP4sfFD0n6w==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.12.2",
-        "@umbraco-ui/uui-icon-registry-essential": "1.12.2"
+        "@umbraco-ui/uui-base": "1.17.3",
+        "@umbraco-ui/uui-icon-registry-essential": "1.17.3"
+      }
+    },
+    "node_modules/@umbraco-ui/uui-button-copy-text": {
+      "version": "1.17.3",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-button-copy-text/-/uui-button-copy-text-1.17.3.tgz",
+      "integrity": "sha512-jeP8QHctw3U2InbyPxaXIJ7Ty9raYGDCMaVdcwlAu/ZM+y7tgQKxKSAAKSc3cgAKBK7Bzmvlpl34qTYlrXiztQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@umbraco-ui/uui-base": "1.17.3",
+        "@umbraco-ui/uui-button": "1.17.3"
       }
     },
     "node_modules/@umbraco-ui/uui-button-group": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-button-group/-/uui-button-group-1.12.2.tgz",
-      "integrity": "sha512-VxWICU4hmYCORmo8JzXgSyzpa82/M3OyTxfn/kX+jHg0rk9vMg4JArQJp4NF9qhgOWsHx0ED5yURTTOtbNqFTQ==",
+      "version": "1.17.3",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-button-group/-/uui-button-group-1.17.3.tgz",
+      "integrity": "sha512-kEHEknYycvekd0U8fSldbBbPNIqSPmhj1pdCnZgW3QPrIot0Jl2biI50+d3lSll9/Lf19Y5m7txysunp3t+Snw==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.12.2"
+        "@umbraco-ui/uui-base": "1.17.3"
       }
     },
     "node_modules/@umbraco-ui/uui-button-inline-create": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-button-inline-create/-/uui-button-inline-create-1.12.2.tgz",
-      "integrity": "sha512-YvJTwlA2ZUhepHsmc/WwP3OqG7lkrlVmAcgG7uBbasNMwDYtLWcudMrv/NSHFrCpQe0VePyr7U4YtJqyQrbDTg==",
+      "version": "1.17.3",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-button-inline-create/-/uui-button-inline-create-1.17.3.tgz",
+      "integrity": "sha512-Z1RwWVfpcBcvBVNi82xN7VG/9+ZDmZA9N8ysTB9bNeb96WCumGgfRy1Nf8QRtxIS6mcZmxLd5ozdc8Ae4LL9tA==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.12.2"
+        "@umbraco-ui/uui-base": "1.17.3"
       }
     },
     "node_modules/@umbraco-ui/uui-card": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-card/-/uui-card-1.12.2.tgz",
-      "integrity": "sha512-/FqFYrQxKu38+s3y7XpiO8wW7Z2T7cyst2LvMajG+3U9KPi4A0pwxaRBlli4ay79/9V9uFEGTc4dKjB+jFKl6w==",
+      "version": "1.17.3",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-card/-/uui-card-1.17.3.tgz",
+      "integrity": "sha512-LLJaEv20KGNaE6AB+zmYUbJXq6D4PuYnBjErK6QsBWbN/bihU83SQgV/pv3vbQYYH3zLE+5iQl4NY9XK1BE49g==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.12.2"
+        "@umbraco-ui/uui-base": "1.17.3",
+        "@umbraco-ui/uui-checkbox": "1.17.3"
       }
     },
     "node_modules/@umbraco-ui/uui-card-block-type": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-card-block-type/-/uui-card-block-type-1.12.2.tgz",
-      "integrity": "sha512-aydgrznHaIUrJpHrwftjPtnaXVQOLe+r6VWrtyWNSPM4ivUeT5WaH/FVMc90Q6yWfIF3y2a3yCIQAGEqAXghhQ==",
+      "version": "1.17.3",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-card-block-type/-/uui-card-block-type-1.17.3.tgz",
+      "integrity": "sha512-WF/SJ1BrxnAajaU+py4ddZ/rf1mT3tddfx75kPXiA3880rDHOwWTznYWVXeMBNZrZeR34hQGe6L+RLjirDG2MQ==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.12.2",
-        "@umbraco-ui/uui-card": "1.12.2"
+        "@umbraco-ui/uui-base": "1.17.3",
+        "@umbraco-ui/uui-card": "1.17.3"
       }
     },
     "node_modules/@umbraco-ui/uui-card-content-node": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-card-content-node/-/uui-card-content-node-1.12.2.tgz",
-      "integrity": "sha512-yuNlbrjwphzMPv2xMHca8YUr+NH7FqeP0EjVjhhDSsOJVUZ8uj8Udoq4YIkypOAGAyG+N63jCzLvVTTR71LxGA==",
+      "version": "1.17.3",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-card-content-node/-/uui-card-content-node-1.17.3.tgz",
+      "integrity": "sha512-YkUMfc4GExzRC1RJKICc4Py0SLCxMHDwfnkJCeyu/PBHD70uqcykkNFTQB76oG5MQwf5xHqaGBju2o2p+LPOmA==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.12.2",
-        "@umbraco-ui/uui-card": "1.12.2",
-        "@umbraco-ui/uui-icon": "1.12.2"
+        "@umbraco-ui/uui-base": "1.17.3",
+        "@umbraco-ui/uui-card": "1.17.3",
+        "@umbraco-ui/uui-icon": "1.17.3"
       }
     },
     "node_modules/@umbraco-ui/uui-card-media": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-card-media/-/uui-card-media-1.12.2.tgz",
-      "integrity": "sha512-37Zful2c9UhDxw7qYWR2F2wdt5Qs5yMjcE0Q5R1ZRA5SFba7qgY0W4YW2iAAPMk2xvDyueaTnbVy1v6gG/jtYw==",
+      "version": "1.17.3",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-card-media/-/uui-card-media-1.17.3.tgz",
+      "integrity": "sha512-5pf6Ehh/Lex3rGnUHfHcxZfSqUwZ8G98zFMuGTmXSFax63w0moM+pAlt7Fv3ZpADgWzwFL+n+R+f09S78oz3Rw==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.12.2",
-        "@umbraco-ui/uui-card": "1.12.2",
-        "@umbraco-ui/uui-symbol-file": "1.12.2",
-        "@umbraco-ui/uui-symbol-folder": "1.12.2"
+        "@umbraco-ui/uui-base": "1.17.3",
+        "@umbraco-ui/uui-card": "1.17.3",
+        "@umbraco-ui/uui-symbol-file": "1.17.3",
+        "@umbraco-ui/uui-symbol-folder": "1.17.3"
       }
     },
     "node_modules/@umbraco-ui/uui-card-user": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-card-user/-/uui-card-user-1.12.2.tgz",
-      "integrity": "sha512-fwuYQvXjjiLTv0ykDpg+GpcoG3af3ZHUPTRbDa5W8ygAYlTRUvENSXc2qOUocy9XmXOa0p+P0NhenVSqOJpSIw==",
+      "version": "1.17.3",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-card-user/-/uui-card-user-1.17.3.tgz",
+      "integrity": "sha512-b6vYP1TjTGltG9XIsiU3GndnetT4pzteqNTNniFp3dnqOG2Q90ERHm5Zuyo+j6hKhpunGzQX1Uud3ZHtvxPF0g==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-avatar": "1.12.2",
-        "@umbraco-ui/uui-base": "1.12.2",
-        "@umbraco-ui/uui-card": "1.12.2"
+        "@umbraco-ui/uui-avatar": "1.17.3",
+        "@umbraco-ui/uui-base": "1.17.3",
+        "@umbraco-ui/uui-card": "1.17.3"
       }
     },
     "node_modules/@umbraco-ui/uui-caret": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-caret/-/uui-caret-1.12.2.tgz",
-      "integrity": "sha512-7zVDVzvLszVld9E/pGSGFRgpp+rIipB1sY/r4xDYQ70g+ljlegOfMc3bvGs/topcMM+IlcQO8EOotlps4P44Jw==",
+      "version": "1.17.3",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-caret/-/uui-caret-1.17.3.tgz",
+      "integrity": "sha512-zCHdmiaDNgUG0jEyzK5dEYrqE85pIXl/NzPBJJdcYdKlrF6sIvdR/lJhZ5t8fMaWN6/91kqL4sdILy81733rQg==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.12.2"
+        "@umbraco-ui/uui-base": "1.17.3"
       }
     },
     "node_modules/@umbraco-ui/uui-checkbox": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-checkbox/-/uui-checkbox-1.12.2.tgz",
-      "integrity": "sha512-C6SSAUq9JfHHWCz9LLlOOmwET1vDsLKKiYv94LIqn8Zj4H3f1bRgUnSfVPVCfy1+p//Ut8SLw2vTFcTz0F21EA==",
+      "version": "1.17.3",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-checkbox/-/uui-checkbox-1.17.3.tgz",
+      "integrity": "sha512-Bk70t/9+4492arU3tvhXJpwxgnAPfPgC/cP5bNcM2PbgYKhhqSNSj7ar0Kx3WCazb3IwDicqC13AYxFxNmr/lQ==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.12.2",
-        "@umbraco-ui/uui-boolean-input": "1.12.2",
-        "@umbraco-ui/uui-icon-registry-essential": "1.12.2"
+        "@umbraco-ui/uui-base": "1.17.3",
+        "@umbraco-ui/uui-boolean-input": "1.17.3",
+        "@umbraco-ui/uui-icon-registry-essential": "1.17.3"
       }
     },
     "node_modules/@umbraco-ui/uui-color-area": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-color-area/-/uui-color-area-1.12.2.tgz",
-      "integrity": "sha512-W5qOBIvTiHGxFJcc1h3H+CdLHLY4K6QRIXU7I2BEII296PbUMwKaA8WFXAvwSq1KzmCkOJP2hPa4yxQ/qKBzJQ==",
+      "version": "1.17.3",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-color-area/-/uui-color-area-1.17.3.tgz",
+      "integrity": "sha512-Ba1CO1hBetldzPkLOF+7ZWCnt1P2Ima07GSzeCChIKCLDZZl+Pwejp4v6ZubxtiQhgBXAFewzoaEyigpAz0i1g==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.12.2",
+        "@umbraco-ui/uui-base": "1.17.3",
         "colord": "^2.9.3"
       }
     },
     "node_modules/@umbraco-ui/uui-color-picker": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-color-picker/-/uui-color-picker-1.12.2.tgz",
-      "integrity": "sha512-t/FB6h1rdNzPa94dIfjGG50yRNmk/7wMjrktKjkZHt+wGWKvjM+I1RjatArZbCAmSV4EQH/7hqyvP6R1OoLIog==",
+      "version": "1.17.3",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-color-picker/-/uui-color-picker-1.17.3.tgz",
+      "integrity": "sha512-VBm8lUESSwmTURl6AP1tUobEitkhxAc8Hv01bkrEhGozh32UqtcakKAhqPyGKwxWZoNeamL9/w2zaMH7OUafSA==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.12.2",
-        "@umbraco-ui/uui-popover-container": "1.12.2",
+        "@umbraco-ui/uui-base": "1.17.3",
+        "@umbraco-ui/uui-popover-container": "1.17.3",
         "colord": "^2.9.3"
       }
     },
     "node_modules/@umbraco-ui/uui-color-slider": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-color-slider/-/uui-color-slider-1.12.2.tgz",
-      "integrity": "sha512-00LxQigqY+04eG0IzHY//Uf010u50DeCQ88ZvCV1MjPNH7T4auEC2/H/O7FYoHhwQB6Ez+ZpYA9ds/NbmTCuVg==",
+      "version": "1.17.3",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-color-slider/-/uui-color-slider-1.17.3.tgz",
+      "integrity": "sha512-Kbfz+LLM0O2lZDTZcZ5d4RJQalOLjKXIjH+NIUrzkMKIOQpaUOGosPJw2yzk9dryxraWD9NKm2+qVybRkZJkLQ==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.12.2"
+        "@umbraco-ui/uui-base": "1.17.3"
       }
     },
     "node_modules/@umbraco-ui/uui-color-swatch": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-color-swatch/-/uui-color-swatch-1.12.2.tgz",
-      "integrity": "sha512-fDODPeuKirwSyIOhEY46J7Ml5RJcuaeMyLBshWT9bl8pNts9zIlKSvn3oSlZ9mZ7N/Ym/3R2c+33i5avoA+rIA==",
+      "version": "1.17.3",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-color-swatch/-/uui-color-swatch-1.17.3.tgz",
+      "integrity": "sha512-RunDonsYl7JBFOSS3hvr0HPCE2+c407+Tm1rd0X6S04I5m6JPvdeozwWT6tVIa42cAtRcAno5QnilSTDj9i8kw==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.12.2",
-        "@umbraco-ui/uui-icon-registry-essential": "1.12.2",
+        "@umbraco-ui/uui-base": "1.17.3",
+        "@umbraco-ui/uui-icon-registry-essential": "1.17.3",
         "colord": "^2.9.3"
       }
     },
     "node_modules/@umbraco-ui/uui-color-swatches": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-color-swatches/-/uui-color-swatches-1.12.2.tgz",
-      "integrity": "sha512-kr9gYjYFQR8mavmDJS+I2t/n5wC6kWbCaZHnJzcs3unOX2jzKHnOqJ8N05y8vc2NZP1pOKSOzoIN1Y6N3qxU+g==",
+      "version": "1.17.3",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-color-swatches/-/uui-color-swatches-1.17.3.tgz",
+      "integrity": "sha512-2XSzT51adGe7KN4cl9K0Moq3eXbL8lfhl1rXwWR4kbR/8hs61yLQxqr+/YfgTF2tJz5sHvl6IKkkd+WP50zWfA==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.12.2",
-        "@umbraco-ui/uui-color-swatch": "1.12.2"
+        "@umbraco-ui/uui-base": "1.17.3",
+        "@umbraco-ui/uui-color-swatch": "1.17.3"
       }
     },
     "node_modules/@umbraco-ui/uui-combobox": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-combobox/-/uui-combobox-1.12.2.tgz",
-      "integrity": "sha512-ln7IoQQJ65zknIl5k44E61S0DgW1e7fo/IEuMlgbrmkPnEbkLqV5HVYXIR3377VvfwqbZ44npxegOZBUuuWGlw==",
+      "version": "1.17.3",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-combobox/-/uui-combobox-1.17.3.tgz",
+      "integrity": "sha512-JVqxnzh9ROvCuvSwKP69p26SmHg30L7srqkBj4lXSMVXatVQ7bAGsTTe/QRfjnsE7NJM82/9upMaKrb46keU5g==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.12.2",
-        "@umbraco-ui/uui-button": "1.12.2",
-        "@umbraco-ui/uui-combobox-list": "1.12.2",
-        "@umbraco-ui/uui-icon": "1.12.2",
-        "@umbraco-ui/uui-popover-container": "1.12.2",
-        "@umbraco-ui/uui-scroll-container": "1.12.2",
-        "@umbraco-ui/uui-symbol-expand": "1.12.2"
+        "@umbraco-ui/uui-base": "1.17.3",
+        "@umbraco-ui/uui-button": "1.17.3",
+        "@umbraco-ui/uui-combobox-list": "1.17.3",
+        "@umbraco-ui/uui-icon": "1.17.3",
+        "@umbraco-ui/uui-popover-container": "1.17.3",
+        "@umbraco-ui/uui-scroll-container": "1.17.3",
+        "@umbraco-ui/uui-symbol-expand": "1.17.3"
       }
     },
     "node_modules/@umbraco-ui/uui-combobox-list": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-combobox-list/-/uui-combobox-list-1.12.2.tgz",
-      "integrity": "sha512-tBtQgQKB6kgPwRSkXM9kShNfC4Zed7V1hstCjVFy1wkRU+IinVYiN28NMNdSvDWmmxkRcIVOt7lY70T0fgPPMw==",
+      "version": "1.17.3",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-combobox-list/-/uui-combobox-list-1.17.3.tgz",
+      "integrity": "sha512-qWNtKOiWsPbNlUS+/P2E/YpNg5GLUwIG3pIdqDxbhAPOxg3VmX0CT520Spd6aIicPAtX9YaTNbmyg2M3G+xlqA==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.12.2"
+        "@umbraco-ui/uui-base": "1.17.3"
       }
     },
     "node_modules/@umbraco-ui/uui-css": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-css/-/uui-css-1.12.1.tgz",
-      "integrity": "sha512-cWdoJw3OjdZ5QUoXhUufp/8mdGkVJ4DiI7/NgPaU2GrMbo+c1Q2cx4ST2/K0Q7nY6qa4P4WCSLMoFGyFoOwLKQ==",
+      "version": "1.17.3",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-css/-/uui-css-1.17.3.tgz",
+      "integrity": "sha512-LjmawpW91rWGnXSGmmZOusw7+6CP2AgLD8iep5Cp9bOzFWDXJXzEIyRtH7Aj27mD82kJDeGgQ+Wwf9XRIGnejw==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -1829,659 +1940,699 @@
       }
     },
     "node_modules/@umbraco-ui/uui-dialog": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-dialog/-/uui-dialog-1.12.2.tgz",
-      "integrity": "sha512-YfHE4RTRKJiSi/ZCnZMJs+eImXx64JrZmu39bEb6FBAnMpqAMxeq70Nll4Nk43nL6liARv1bXP8OKZd2b7CPgQ==",
+      "version": "1.17.3",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-dialog/-/uui-dialog-1.17.3.tgz",
+      "integrity": "sha512-kN/BRrXcAsLzLJZLTvVayPs5U8iXMNSW9RcUZwIGj+3qAi3EdVy2yr+KTjWRlRQc9MjmSXrda976uhHiQ7yY+g==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.12.2",
-        "@umbraco-ui/uui-css": "1.12.1"
+        "@umbraco-ui/uui-base": "1.17.3",
+        "@umbraco-ui/uui-css": "1.17.3"
       }
     },
     "node_modules/@umbraco-ui/uui-dialog-layout": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-dialog-layout/-/uui-dialog-layout-1.12.2.tgz",
-      "integrity": "sha512-Xy+Ocwia0xRcpUUARTdXgSgf5NIG2mlneDkiz6dsrIsFZ1IysXCnfh/4dXw57fneO+PyHI86bDwb9aFlWvve7Q==",
+      "version": "1.17.3",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-dialog-layout/-/uui-dialog-layout-1.17.3.tgz",
+      "integrity": "sha512-BuvuSXGdo6MMnn65cOa6EvLzzZ//NHi2bcgIVtJ9JpikcTuIbWMSSiJ1KUA4fHJ2GrYtE4G30pB9iyQmUkWc7A==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.12.2"
+        "@umbraco-ui/uui-base": "1.17.3"
       }
     },
     "node_modules/@umbraco-ui/uui-file-dropzone": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-file-dropzone/-/uui-file-dropzone-1.12.2.tgz",
-      "integrity": "sha512-5B/1umH72IrxwlQ+4ivKDSIXXcGbfFuhvo98v1nuIF5MGl6wmoiG/lDilhny08RJMHwlcRkdYCtCChtuWEyVUg==",
+      "version": "1.17.3",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-file-dropzone/-/uui-file-dropzone-1.17.3.tgz",
+      "integrity": "sha512-NBXDioz4UGJLyQwWfpjeKkg14yvZ+mPI0fASDPKJX0I6lWu+6uv/nRLMKniARld2f8HYrdD90zYe/fd4rlN8tw==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.12.2",
-        "@umbraco-ui/uui-symbol-file-dropzone": "1.12.2"
+        "@umbraco-ui/uui-base": "1.17.3",
+        "@umbraco-ui/uui-symbol-file-dropzone": "1.17.3"
       }
     },
     "node_modules/@umbraco-ui/uui-file-preview": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-file-preview/-/uui-file-preview-1.12.2.tgz",
-      "integrity": "sha512-Oxkm7x3V/aCHPQDNh8loMESWswYCyDJeZazbhGig7mU6zbms7Vl3Vm46CIKEBva6IMy1p1AsNOgSjY4wmIvXsw==",
+      "version": "1.17.3",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-file-preview/-/uui-file-preview-1.17.3.tgz",
+      "integrity": "sha512-JzW27JBmAVbrbS6OHAeouJ8J0IL3RneWuPiS/T8deyMfWtCxqGd/IJlaSpg77enhAoaGjJRmHpXTSQEU/lO5xw==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.12.2",
-        "@umbraco-ui/uui-symbol-file": "1.12.2",
-        "@umbraco-ui/uui-symbol-file-thumbnail": "1.12.2",
-        "@umbraco-ui/uui-symbol-folder": "1.12.2"
+        "@umbraco-ui/uui-base": "1.17.3",
+        "@umbraco-ui/uui-symbol-file": "1.17.3",
+        "@umbraco-ui/uui-symbol-file-thumbnail": "1.17.3",
+        "@umbraco-ui/uui-symbol-folder": "1.17.3"
       }
     },
     "node_modules/@umbraco-ui/uui-form": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-form/-/uui-form-1.12.2.tgz",
-      "integrity": "sha512-35CEeSCODTMaJi7JlvBl988tB0MIbocNg5ewCLeqm2CLVvW1UQi4V+835CY1fjgiR6D8co6Kz6KCR/9aibX5Gg==",
+      "version": "1.17.3",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-form/-/uui-form-1.17.3.tgz",
+      "integrity": "sha512-3Gl0t8LDv5co8C3sTkfkJQj5oGYbvBG/gJNnz2+Wv7s79fhUoCnxzHujU/dFKP8NyaIilAST+4RfHZ4bj1UAGg==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.12.2"
+        "@umbraco-ui/uui-base": "1.17.3"
       }
     },
     "node_modules/@umbraco-ui/uui-form-layout-item": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-form-layout-item/-/uui-form-layout-item-1.12.2.tgz",
-      "integrity": "sha512-qc4JJhhtM7HsVT1DBtw2xRbayLEWvFDwXROXgmwTUMOVZJ9qGFpSN6EWymm9fr+gBYcbwii6ZKg0ujIeHDILTw==",
+      "version": "1.17.3",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-form-layout-item/-/uui-form-layout-item-1.17.3.tgz",
+      "integrity": "sha512-qC8f80z/NsfGrcDXucqdd4fsix8i5mRJzYuZLvKJX2pfQGg1SfKIL1nRq5kkre7qrPRzSAJKzP11jkuOgpgC9g==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.12.2",
-        "@umbraco-ui/uui-form-validation-message": "1.12.2"
+        "@umbraco-ui/uui-base": "1.17.3",
+        "@umbraco-ui/uui-form-validation-message": "1.17.3"
       }
     },
     "node_modules/@umbraco-ui/uui-form-validation-message": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-form-validation-message/-/uui-form-validation-message-1.12.2.tgz",
-      "integrity": "sha512-MQ0nNQcNpawQUZA+JGYPbGW8Go9b9nj4loK26Op0qvInQpbe9mHbHAhWOdbPTBLoJSYnXpo90/3E9ycU9p9PEQ==",
+      "version": "1.17.3",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-form-validation-message/-/uui-form-validation-message-1.17.3.tgz",
+      "integrity": "sha512-frkIM6gKm2SeV/2MYUdw7RgWLCzsYIND7dgKL9Pt7x9bYsOjRHCwx1Ti3fg1E4OBGSURF46grRrIQmajaxKm6w==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.12.2"
+        "@umbraco-ui/uui-base": "1.17.3"
       }
     },
     "node_modules/@umbraco-ui/uui-icon": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-icon/-/uui-icon-1.12.2.tgz",
-      "integrity": "sha512-sAz08736Jt1y6pPZSBafNT04w9YCnck46whCZUhx7FX7kiKctJX0Xr9GVZH99YAGxnbXnNx0YsN6PqFfz92FzA==",
+      "version": "1.17.3",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-icon/-/uui-icon-1.17.3.tgz",
+      "integrity": "sha512-gYJeTqEYZTod8i2LvBLtcRu65S+2QMagfEGY4F+vsyVmBDfMpRAfrbZuw8OapYA3vBRYiXxHUMDQHfqFj4ccNg==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.12.2"
+        "@umbraco-ui/uui-base": "1.17.3"
       }
     },
     "node_modules/@umbraco-ui/uui-icon-registry": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-icon-registry/-/uui-icon-registry-1.12.2.tgz",
-      "integrity": "sha512-CXinq7uwca8QzIMCMBkUNkHoq9KV5ioxJSY4+2b5s7lpS8zK+Zoe+zzt5QL/bOCET6TTGZifpCiZRIiRy1Mffg==",
+      "version": "1.17.3",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-icon-registry/-/uui-icon-registry-1.17.3.tgz",
+      "integrity": "sha512-As6BTo45VcXrULfmEeqdHYrN3VVpx7VkxHqPV9EY49bxWLQZPjI+dkgX8tDFeRoARktFDy5JFcXnS9L+ViZGXA==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.12.2",
-        "@umbraco-ui/uui-icon": "1.12.2"
+        "@umbraco-ui/uui-base": "1.17.3",
+        "@umbraco-ui/uui-icon": "1.17.3"
       }
     },
     "node_modules/@umbraco-ui/uui-icon-registry-essential": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-icon-registry-essential/-/uui-icon-registry-essential-1.12.2.tgz",
-      "integrity": "sha512-s53QmcXVzrLDwpVP3WZW1pekG95kVrjgHDyTo2T3a2J4ovvEEYpZ8/Jmf/3lJVj5CpvQV+I1l/Wx3zFtniT91g==",
+      "version": "1.17.3",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-icon-registry-essential/-/uui-icon-registry-essential-1.17.3.tgz",
+      "integrity": "sha512-abJx8uR/BhpMYmAUUnIWYuYAgG/G7vHCKX+LOkO894qy6knspuaxbhimp0o490lMEOSTxHXnA2VakcGcuXXbpA==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.12.2",
-        "@umbraco-ui/uui-icon-registry": "1.12.2"
+        "@umbraco-ui/uui-base": "1.17.3",
+        "@umbraco-ui/uui-icon-registry": "1.17.3"
       }
     },
     "node_modules/@umbraco-ui/uui-input": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-input/-/uui-input-1.12.2.tgz",
-      "integrity": "sha512-t/QsptHm9jMH8A0iWBvRZ2s/qeKaO5vp1Zf5oBG9RtgZoS7cNowdMQPVp6mXzc1gICc217lNFsxt+MUGVCud2w==",
+      "version": "1.17.3",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-input/-/uui-input-1.17.3.tgz",
+      "integrity": "sha512-8H65YH6ZsiGbmME7IubcnVdq3WzEGoyZu0Kj568sm1r531ht376XYeasMjewTy5k5rWvc9PQZZDsm6suoWHSeg==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.12.2"
+        "@umbraco-ui/uui-base": "1.17.3"
       }
     },
     "node_modules/@umbraco-ui/uui-input-file": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-input-file/-/uui-input-file-1.12.2.tgz",
-      "integrity": "sha512-X/AeocW+1XLroIqsuxB4OBTmFy1n7ZzfxNrtwEsaqM1rbrA3RGY2EIjnt311eoxk9DvFWeG50/gICV85sWWNmQ==",
+      "version": "1.17.3",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-input-file/-/uui-input-file-1.17.3.tgz",
+      "integrity": "sha512-IrHeQ1btodgHAV/gjhgZwbocertS7nelP6mdV36nfpQJulFJLV81uCW8BE2jOvGDvwy9dpm4ySLYnOS74CFOoQ==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-action-bar": "1.12.2",
-        "@umbraco-ui/uui-base": "1.12.2",
-        "@umbraco-ui/uui-button": "1.12.2",
-        "@umbraco-ui/uui-file-dropzone": "1.12.2",
-        "@umbraco-ui/uui-icon": "1.12.2",
-        "@umbraco-ui/uui-icon-registry-essential": "1.12.2"
+        "@umbraco-ui/uui-action-bar": "1.17.3",
+        "@umbraco-ui/uui-base": "1.17.3",
+        "@umbraco-ui/uui-button": "1.17.3",
+        "@umbraco-ui/uui-file-dropzone": "1.17.3",
+        "@umbraco-ui/uui-icon": "1.17.3",
+        "@umbraco-ui/uui-icon-registry-essential": "1.17.3"
       }
     },
     "node_modules/@umbraco-ui/uui-input-lock": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-input-lock/-/uui-input-lock-1.12.2.tgz",
-      "integrity": "sha512-EAjzK0xZbjEEyIqHjMdDPmBQMSay/vbYj65YHb8aJBtYyL17qIqVRMEB9D/tV7cGBp5FbpkpZtb5qWmNVFQtcg==",
+      "version": "1.17.3",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-input-lock/-/uui-input-lock-1.17.3.tgz",
+      "integrity": "sha512-XA1UsSlEzRxXh/8kbiLFH8p+72gfcXR0aKPlH7wvMqM3zMi9iluPQIMO9LfZQFL1Na6CNFzZxZbB37X9eEnENg==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.12.2",
-        "@umbraco-ui/uui-button": "1.12.2",
-        "@umbraco-ui/uui-icon": "1.12.2",
-        "@umbraco-ui/uui-input": "1.12.2"
+        "@umbraco-ui/uui-base": "1.17.3",
+        "@umbraco-ui/uui-button": "1.17.3",
+        "@umbraco-ui/uui-icon": "1.17.3",
+        "@umbraco-ui/uui-input": "1.17.3"
       }
     },
     "node_modules/@umbraco-ui/uui-input-password": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-input-password/-/uui-input-password-1.12.2.tgz",
-      "integrity": "sha512-CYNHiaDmaBDXUYE6XFpO3lpmClwjC6aCgtlYFe8SqFlcyU1KABal36PopxpnIMuKrmMv3LFHw1Jpg5dnjk/hNA==",
+      "version": "1.17.3",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-input-password/-/uui-input-password-1.17.3.tgz",
+      "integrity": "sha512-GNYxNe7HkVF4T/iDeHTMlueTiT/UX4d0wyC7qgA+YOw8bojx2zBEMKaVwaJUkjl65ipdkV9Lub2gsoZp8iw9og==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.12.2",
-        "@umbraco-ui/uui-icon-registry-essential": "1.12.2",
-        "@umbraco-ui/uui-input": "1.12.2"
+        "@umbraco-ui/uui-base": "1.17.3",
+        "@umbraco-ui/uui-icon-registry-essential": "1.17.3",
+        "@umbraco-ui/uui-input": "1.17.3"
       }
     },
     "node_modules/@umbraco-ui/uui-keyboard-shortcut": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-keyboard-shortcut/-/uui-keyboard-shortcut-1.12.2.tgz",
-      "integrity": "sha512-X4ZpIP6AQbx5d3zLVVGqHKIDBli4HwkOsTnepHYFPTykTTiCVBxRiVQ5TRgAM4GjeEaUe/mOyPOCYkVBJ0bKmA==",
+      "version": "1.17.3",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-keyboard-shortcut/-/uui-keyboard-shortcut-1.17.3.tgz",
+      "integrity": "sha512-QFQnAPPWzIE2mePXqHrct50pmAw8FLj4juYmtjXoWMtNGlphxNIZM7wiiuqiHsyThYKCuLLWXNH42ucAw6CEVQ==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.12.2"
+        "@umbraco-ui/uui-base": "1.17.3"
       }
     },
     "node_modules/@umbraco-ui/uui-label": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-label/-/uui-label-1.12.2.tgz",
-      "integrity": "sha512-D4j2XBwtYq2tK/pP+QJuLSxg5NtD+jGEy5DO2qhoRm2VPzGjCWw3irdykVoTIgMRjJiWOQMvE8tpgqPBsBygHw==",
+      "version": "1.17.3",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-label/-/uui-label-1.17.3.tgz",
+      "integrity": "sha512-cLiikdhIVyK/roU0S0NPg+yUqYegnjprOyosNXez46kHdsZTbN45+du3cn9ir3NQmrWJs4njyQeosB+jSSSp1g==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.12.2"
+        "@umbraco-ui/uui-base": "1.17.3"
       }
     },
     "node_modules/@umbraco-ui/uui-loader": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-loader/-/uui-loader-1.12.2.tgz",
-      "integrity": "sha512-vbAds+57/wFelt+F4YdCdZ9dyR9DjBtEEPhcJDbd5yLwbgKnl+ITL6pDtu2kT45cVMacaxxZAdP5SzcwVSnR7g==",
+      "version": "1.17.3",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-loader/-/uui-loader-1.17.3.tgz",
+      "integrity": "sha512-mUfJ8FqxqVg2Csg0D5Bni7OkDxVNGwGhrG9xb+8PDUZQToqK/ojvLju2EX/9acD7ogIT99L4K68AVJ0+I3XvIw==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.12.2"
+        "@umbraco-ui/uui-base": "1.17.3"
       }
     },
     "node_modules/@umbraco-ui/uui-loader-bar": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-loader-bar/-/uui-loader-bar-1.12.2.tgz",
-      "integrity": "sha512-nC678xqAJFH8vKqhewfFi1CEZ8dR5r/s88REILZOwQM8S0c2z9J4bxesmjpr2ZIQ4KQ2l7BCzBdWbyqs+GUHUA==",
+      "version": "1.17.3",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-loader-bar/-/uui-loader-bar-1.17.3.tgz",
+      "integrity": "sha512-rj4sCiKO5glx/uhNn8KxCvM+8dumudUGy4tOMTpdAzbxVpytuLcf4RQSIF32j2CMWNDDS64eoOb1KAZr0Ry8xA==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.12.2"
+        "@umbraco-ui/uui-base": "1.17.3"
       }
     },
     "node_modules/@umbraco-ui/uui-loader-circle": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-loader-circle/-/uui-loader-circle-1.12.2.tgz",
-      "integrity": "sha512-CmjdLDdUM1pRp3dE+WKVEc9dTIQlvYtPtJIjCyNwP403YcKvreGMW6wKMxV/+69IEPjRtTjyaKyprNGnRVRpwg==",
+      "version": "1.17.3",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-loader-circle/-/uui-loader-circle-1.17.3.tgz",
+      "integrity": "sha512-dcCeVtmtrssUDo8z41lx68F25Io7mVQgFShhzFgMKUzVWY5LuoRdHEjNPkXHt6DaNOkik+ONr1l9ZeScjPENAw==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.12.2"
+        "@umbraco-ui/uui-base": "1.17.3"
       }
     },
     "node_modules/@umbraco-ui/uui-menu-item": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-menu-item/-/uui-menu-item-1.12.2.tgz",
-      "integrity": "sha512-CvrkPWvfRLGSWFNDq+SCLKUm08DjWzw/nYtGLSmQL9QsXa/SMJMtmmcw2H+OYzk4d/9ME+r0GRralZgDlx08iA==",
+      "version": "1.17.3",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-menu-item/-/uui-menu-item-1.17.3.tgz",
+      "integrity": "sha512-mwA6gPHhPtalvE+RWNOppwxRJa1tLgG+Z117SA/8RIri5HRpEGXcnZ1D1SJXkN3xGC0EnirTgCFsRwpUuF7iaA==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.12.2",
-        "@umbraco-ui/uui-loader-bar": "1.12.2",
-        "@umbraco-ui/uui-symbol-expand": "1.12.2"
+        "@umbraco-ui/uui-base": "1.17.3",
+        "@umbraco-ui/uui-loader-bar": "1.17.3",
+        "@umbraco-ui/uui-symbol-expand": "1.17.3"
       }
     },
     "node_modules/@umbraco-ui/uui-modal": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-modal/-/uui-modal-1.12.2.tgz",
-      "integrity": "sha512-0ZJuMwdpIFDD+vi59gakhL4jsEb+/f/sMIH4yE/np8ccbZNnGSIT0RJPe94lv6b2wPKrjVIQ1VGGrqzY2znh2A==",
+      "version": "1.17.3",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-modal/-/uui-modal-1.17.3.tgz",
+      "integrity": "sha512-OPJzQj4gsd7BZK+O2Kp/XXwwUP8h9lsIa7gvtNrrn6VGl7vRDpud6b0NlhjT7rJ5EgpCLYnLxX87TbdAwio7Tg==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.12.2"
+        "@umbraco-ui/uui-base": "1.17.3"
       }
     },
     "node_modules/@umbraco-ui/uui-pagination": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-pagination/-/uui-pagination-1.12.2.tgz",
-      "integrity": "sha512-TvP0GKewUZndpO7rHlPqbsw5dPqmKBJXs33berhn/crIE2pGnPVEBey3NYLIHBd5CZI5ufn+gGn4NPNVGF+Q9A==",
+      "version": "1.17.3",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-pagination/-/uui-pagination-1.17.3.tgz",
+      "integrity": "sha512-zbAQAiWnQ7CyCtD+ashaI9QUga1N/s6Dg9U8ZdzzknE5pljx957EdBVpcEgXRmTB4UW5DyDYDhPEo5A7+DKQ3g==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.12.2",
-        "@umbraco-ui/uui-button": "1.12.2",
-        "@umbraco-ui/uui-button-group": "1.12.2"
+        "@umbraco-ui/uui-base": "1.17.3",
+        "@umbraco-ui/uui-button": "1.17.3",
+        "@umbraco-ui/uui-button-group": "1.17.3"
       }
     },
     "node_modules/@umbraco-ui/uui-popover": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-popover/-/uui-popover-1.12.2.tgz",
-      "integrity": "sha512-gvSUe7wox0VY/wEm8LLUV//aLVwz7twswWQd9QniR6MdahvwhjWhQ90hTVpir3VAj5GFBaTfSitqeFBElyT1og==",
+      "version": "1.17.3",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-popover/-/uui-popover-1.17.3.tgz",
+      "integrity": "sha512-/TsDXLVqhKuypSycGhhdkraASjp8oC25oVnFYF8Up1KgWZ3FptishMuNV8ppSisKX0NoF01z1OU0ZTlW3EH0jw==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.12.2"
+        "@umbraco-ui/uui-base": "1.17.3"
       }
     },
     "node_modules/@umbraco-ui/uui-popover-container": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-popover-container/-/uui-popover-container-1.12.2.tgz",
-      "integrity": "sha512-2z//P49B1zyoN/tWdVZp6Q+8qRnbbtGb4CBveXZeuuirzNxhMOA/E77Y0aJmzjn8yTRoooMGmYzRYd+4zJGNJQ==",
+      "version": "1.17.3",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-popover-container/-/uui-popover-container-1.17.3.tgz",
+      "integrity": "sha512-+9VzTi4n9ke3OIEJDb1W5IAIyYUJHl65zBRruRorSpnDCtcYXoYiuxmI0C+CnYQ+TVS1MxxTSrfMTzs/j/y3KQ==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.12.2"
+        "@umbraco-ui/uui-base": "1.17.3"
       }
     },
     "node_modules/@umbraco-ui/uui-progress-bar": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-progress-bar/-/uui-progress-bar-1.12.2.tgz",
-      "integrity": "sha512-PW5TKeg58Lv3WfX6Sp/EPWCsl9oYqQovvl/7y0pxy7xFnSYma5tFQ+XX0mD1rKw7ed3Unlek/Ma9u79Z9GVhDQ==",
+      "version": "1.17.3",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-progress-bar/-/uui-progress-bar-1.17.3.tgz",
+      "integrity": "sha512-tJ5dcVS56T9Vyp4denVDF2VL5nhzlkSvr+a4eLruhCVHsi2Nlbf1QIx8WgVS8xSDQ4DN3YsSnaeBSEJYPbfLeA==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.12.2"
+        "@umbraco-ui/uui-base": "1.17.3"
       }
     },
     "node_modules/@umbraco-ui/uui-radio": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-radio/-/uui-radio-1.12.2.tgz",
-      "integrity": "sha512-KfXA6+YtueMsxQTjzjp8gVgGJAk17BW9d4Da4h7kYhZGekfWK996ohEgGWF7vj/Q4Ai229OuX7zNJdufCGZIfw==",
+      "version": "1.17.3",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-radio/-/uui-radio-1.17.3.tgz",
+      "integrity": "sha512-kMorQngogGk3wVgBgHrmlSbX3saY3NNsHzikhQOzYct+TJjLfJ6PeomaPyUvD0yxb0tzUTbNYPhaM2XoU7hmoQ==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.12.2"
+        "@umbraco-ui/uui-base": "1.17.3"
       }
     },
     "node_modules/@umbraco-ui/uui-range-slider": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-range-slider/-/uui-range-slider-1.12.2.tgz",
-      "integrity": "sha512-m4ATwJYdasF4jfLLHxfFw+2n0uQmZdOha4vxzHbTreyO/gnwn8hLfICA1h9zjoZIqUGMtQ9KlhIaUezvgMpGFw==",
+      "version": "1.17.3",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-range-slider/-/uui-range-slider-1.17.3.tgz",
+      "integrity": "sha512-u6k1QHq4xmuBakQ2m4dkCJ/hhrol2vmOFAdrKCzR+qriiaJBYrgD5Dm3DhiUVrpowSZdkeBAR4Ihn4Ir7TRLPw==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.12.2"
+        "@umbraco-ui/uui-base": "1.17.3"
       }
     },
     "node_modules/@umbraco-ui/uui-ref": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-ref/-/uui-ref-1.12.2.tgz",
-      "integrity": "sha512-uwQmaiuwphD1ereZLBhcUDMUaUosO0sV6NrBOh9KLWhkmeqYjuFFG2+CRxdhQrKb1ltZfLzAmzYfGp6AoFkvmw==",
+      "version": "1.17.3",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-ref/-/uui-ref-1.17.3.tgz",
+      "integrity": "sha512-xQQqmSRNFl0yCEzn6Cu8nfTAeoRo9ZxFzzRp1CNMTxfOxVhkU7ZekYzuqoEs/sTD8yPF5uIfkE/iM69UVS/6xQ==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.12.2"
+        "@umbraco-ui/uui-base": "1.17.3"
       }
     },
     "node_modules/@umbraco-ui/uui-ref-list": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-ref-list/-/uui-ref-list-1.12.2.tgz",
-      "integrity": "sha512-b7reEiwfGy17Ns3qFQoO0TnngxAUclhj0jR7gLIk7dHNJZw45r37crPMkVs2CnRj657nn4DmghjQgCLDSCre9w==",
+      "version": "1.17.3",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-ref-list/-/uui-ref-list-1.17.3.tgz",
+      "integrity": "sha512-HEIm/gSdTxGkmO8kvIlzlk219B/MOt/KVzsyGg168shm4I1Q/JA6lQz43o1cfu6hHHzvKxpehFogzO0sameCgA==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.12.2"
+        "@umbraco-ui/uui-base": "1.17.3"
       }
     },
     "node_modules/@umbraco-ui/uui-ref-node": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-ref-node/-/uui-ref-node-1.12.2.tgz",
-      "integrity": "sha512-RFma47ixyYNdcMwel1+dte5fGnULczWZpzh1CvAiI9JNKzy9ItUFi70UiFKMrkOY0gT+910xgeWhk4jPTJJgpQ==",
+      "version": "1.17.3",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-ref-node/-/uui-ref-node-1.17.3.tgz",
+      "integrity": "sha512-zOopC75LakngPJTqk4CA9DkMUiNVEZAkL/FfsgtUfl/u5RxcVta7Uj/2efxWwuFJbLbCLb16nbfbhaiEy+Ti/Q==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.12.2",
-        "@umbraco-ui/uui-icon": "1.12.2",
-        "@umbraco-ui/uui-ref": "1.12.2"
+        "@umbraco-ui/uui-base": "1.17.3",
+        "@umbraco-ui/uui-icon": "1.17.3",
+        "@umbraco-ui/uui-ref": "1.17.3"
       }
     },
     "node_modules/@umbraco-ui/uui-ref-node-data-type": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-ref-node-data-type/-/uui-ref-node-data-type-1.12.2.tgz",
-      "integrity": "sha512-s8eviANQTHaNXSVa4U61wJcPCAwzUj6YrIvw7T3Ioe4HgIQvTotIWaCkek+p4ttl3irnnBsRXfGdW+yWuaEnEg==",
+      "version": "1.17.3",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-ref-node-data-type/-/uui-ref-node-data-type-1.17.3.tgz",
+      "integrity": "sha512-sOI1Z0v2NE5qzFcXndY71d+P6zztgBAlSTmZzKr7oe9CzlE/5diVKP1zKBcS8ZKeFPCC2MmommSoYfDbUnWzNQ==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.12.2",
-        "@umbraco-ui/uui-ref-node": "1.12.2"
+        "@umbraco-ui/uui-base": "1.17.3",
+        "@umbraco-ui/uui-ref-node": "1.17.3"
       }
     },
     "node_modules/@umbraco-ui/uui-ref-node-document-type": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-ref-node-document-type/-/uui-ref-node-document-type-1.12.2.tgz",
-      "integrity": "sha512-Dg+SAAcMSqr0EvX6IY2jjGk9I8bbgo1Pe6L5c9g0CBPmQ8H+0qOKDdSojWzn/qohtfdAIvN+21Q0AvCovVA9rA==",
+      "version": "1.17.3",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-ref-node-document-type/-/uui-ref-node-document-type-1.17.3.tgz",
+      "integrity": "sha512-/EKt7w1vHGoa4WbqsnjHIzmQOG5x9Sy+wbwo6gU4s5SdxGFTAeCcIeybMqb/+blr3P0BYOS6MC+UU1osViva2g==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.12.2",
-        "@umbraco-ui/uui-ref-node": "1.12.2"
+        "@umbraco-ui/uui-base": "1.17.3",
+        "@umbraco-ui/uui-ref-node": "1.17.3"
       }
     },
     "node_modules/@umbraco-ui/uui-ref-node-form": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-ref-node-form/-/uui-ref-node-form-1.12.2.tgz",
-      "integrity": "sha512-jnPNmLK8LvZenH2MY9Ea8R+4JkuDNMoBfUFVnhaLg+dHp7tsrg9opIONDNOIJJTYHryHdZ+/ksvQGW6ZWlACgQ==",
+      "version": "1.17.3",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-ref-node-form/-/uui-ref-node-form-1.17.3.tgz",
+      "integrity": "sha512-A3+MFnt84KzfTw5fXcjmcOsz1VVEwayy6bEw5XiPqEK6JvQw1dJHsKZd7Mfu5TQcphAEWI2h2zRB9NtgIO4Ciw==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.12.2",
-        "@umbraco-ui/uui-ref-node": "1.12.2"
+        "@umbraco-ui/uui-base": "1.17.3",
+        "@umbraco-ui/uui-ref-node": "1.17.3"
       }
     },
     "node_modules/@umbraco-ui/uui-ref-node-member": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-ref-node-member/-/uui-ref-node-member-1.12.2.tgz",
-      "integrity": "sha512-ft0SRlDZ49eRbV3Xk7JtDfR5UraULoeTfYe/MHZkmAzhrDKeTtnd9oVYUQ27qsYs6EVneQ8byydwXrmSMloc8A==",
+      "version": "1.17.3",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-ref-node-member/-/uui-ref-node-member-1.17.3.tgz",
+      "integrity": "sha512-FlznsRXFdNGW/2L7zxWWdtBJ1jgoqnVbEVp4gwiapIYwHS7sd7IwEcVUhrCKRUBlnmAz1oZWbyRqkoQVffEOgQ==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.12.2",
-        "@umbraco-ui/uui-ref-node": "1.12.2"
+        "@umbraco-ui/uui-base": "1.17.3",
+        "@umbraco-ui/uui-ref-node": "1.17.3"
       }
     },
     "node_modules/@umbraco-ui/uui-ref-node-package": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-ref-node-package/-/uui-ref-node-package-1.12.2.tgz",
-      "integrity": "sha512-TX9PCPpeOWpl5vK8o/QjXgEWXOt7z0lQK8wlUHYSz+a3/wcmDZD0J/OXkmpvVyS2lXe6pqR8HJ/+FwcnrOm/9w==",
+      "version": "1.17.3",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-ref-node-package/-/uui-ref-node-package-1.17.3.tgz",
+      "integrity": "sha512-5v/dvKbvfg3RjbJNtkGkgNrpicqbkwlehJQGxhbixpSqUiROKGUWZZ6gzlrw9mFz9by2OXuBQTCJQgXQt9mmZQ==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.12.2",
-        "@umbraco-ui/uui-ref-node": "1.12.2"
+        "@umbraco-ui/uui-base": "1.17.3",
+        "@umbraco-ui/uui-ref-node": "1.17.3"
       }
     },
     "node_modules/@umbraco-ui/uui-ref-node-user": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-ref-node-user/-/uui-ref-node-user-1.12.2.tgz",
-      "integrity": "sha512-sBMICX3vxJd9WjJPWqVnhUhJL+JMuzGzZVUfHlzIjrdpANZZ6FrhnvYkHXhW83KsrfwLsY5/3CXr22xZSsVajA==",
+      "version": "1.17.3",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-ref-node-user/-/uui-ref-node-user-1.17.3.tgz",
+      "integrity": "sha512-V1qiUrZpl0o7XiluWoegZbXgOuuxGsilDjjoC6p8+f0A7qIC37UIRYq+4gJVg4OxabwAisH7LEm5IJFlIgZJSw==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.12.2",
-        "@umbraco-ui/uui-ref-node": "1.12.2"
+        "@umbraco-ui/uui-base": "1.17.3",
+        "@umbraco-ui/uui-ref-node": "1.17.3"
+      }
+    },
+    "node_modules/@umbraco-ui/uui-responsive-container": {
+      "version": "1.17.3",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-responsive-container/-/uui-responsive-container-1.17.3.tgz",
+      "integrity": "sha512-L4BzPIjSkaAEDUppT/66hxsqfDfh1iP42pv68OeqPD9ygw6GU67bv2aOV4N5BFEi1VJHq6Oi3So4RVaeFQtRYg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@umbraco-ui/uui-base": "1.17.3",
+        "@umbraco-ui/uui-button": "1.17.3",
+        "@umbraco-ui/uui-button-group": "1.17.3",
+        "@umbraco-ui/uui-popover-container": "1.17.3",
+        "@umbraco-ui/uui-symbol-more": "1.17.3"
       }
     },
     "node_modules/@umbraco-ui/uui-scroll-container": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-scroll-container/-/uui-scroll-container-1.12.2.tgz",
-      "integrity": "sha512-MI5lpiUeLg1Scf2xHaFzBADAW8CAwcU2yEKOOfOgONuaP6PiUA80YqtE2hCm5BmoldbOYBufCJlFFi2cyuq7HQ==",
+      "version": "1.17.3",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-scroll-container/-/uui-scroll-container-1.17.3.tgz",
+      "integrity": "sha512-k+io6hBzcvUfv+5Zucv68e1oF6UJ2DOgByhM9uIuiHWSZdvodG/3neFEIDPQJ+EaNPcJ6K+QzJs0T16QEZW0cA==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.12.2"
+        "@umbraco-ui/uui-base": "1.17.3"
       }
     },
     "node_modules/@umbraco-ui/uui-select": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-select/-/uui-select-1.12.2.tgz",
-      "integrity": "sha512-TOGodRtumlh1cgC9iKxsV/jEGH2w7bKBjIhyQ42sJ3DXyLPcXVEUooZYmh/3dOf7R/7eHSsZOxH/sskbQlNS2A==",
+      "version": "1.17.3",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-select/-/uui-select-1.17.3.tgz",
+      "integrity": "sha512-y0lapeDWK84R4u2xeNrgex0d5BVHwcljlqejoT8A/tWwTSGJ15viv3mgrJV8j9gkTgYF5Fz22ASZpO8vqC0wEw==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.12.2"
+        "@umbraco-ui/uui-base": "1.17.3"
       }
     },
     "node_modules/@umbraco-ui/uui-slider": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-slider/-/uui-slider-1.12.2.tgz",
-      "integrity": "sha512-Eg0XqIIXwibxq7y4qe0OB9+t7QLetnlBY3i2BSeMPMfarG1NQ6jhWVOv//RKmZ1kqfUh9MCE5tya9T9h68zR1A==",
+      "version": "1.17.3",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-slider/-/uui-slider-1.17.3.tgz",
+      "integrity": "sha512-Aw8dO6EUvpu26yJ24fyazDXhsd94dWMttIiy/Fq1uP49ZsNsphiEWwOamc5fZIMcl7svNy6WBCbaTLEWvWNeUw==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.12.2"
+        "@umbraco-ui/uui-base": "1.17.3"
       }
     },
     "node_modules/@umbraco-ui/uui-symbol-expand": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-symbol-expand/-/uui-symbol-expand-1.12.2.tgz",
-      "integrity": "sha512-zW/ClcJuPCe7ELYHCyoSMm6sGWVPLDbjz8TlE1qambwmFefqTfv69p3nB0YF7QnB+7LR5ePOV63vjZSYWT9/Aw==",
+      "version": "1.17.3",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-symbol-expand/-/uui-symbol-expand-1.17.3.tgz",
+      "integrity": "sha512-mT0sXdERzZBU5ePEiprdpTRcSEASeUErlB/XCyNPiW1FMW62/JNIXXmQ6lPymouzZqjB7z3+/wJR/jKlcpgQdQ==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.12.2"
+        "@umbraco-ui/uui-base": "1.17.3"
       }
     },
     "node_modules/@umbraco-ui/uui-symbol-file": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-symbol-file/-/uui-symbol-file-1.12.2.tgz",
-      "integrity": "sha512-+af95C4eZOdOpqJrt8br1pic1P/NPrnyC1Q4sKLaCReuBqBdaWLl502kAXjlkkoJZsv4GsyzmjiSbBkbRIZCFQ==",
+      "version": "1.17.3",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-symbol-file/-/uui-symbol-file-1.17.3.tgz",
+      "integrity": "sha512-+QMl/OJUNwa2X1NyvAY3Ogko/ijwLhe/SRTQjkF5tqyVq+hJEPDER+Ij1n38FmJuYmmCEkP29KTDECTWcEqnfA==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.12.2"
+        "@umbraco-ui/uui-base": "1.17.3"
       }
     },
     "node_modules/@umbraco-ui/uui-symbol-file-dropzone": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-symbol-file-dropzone/-/uui-symbol-file-dropzone-1.12.2.tgz",
-      "integrity": "sha512-8vmHw+nYZdWgeUVNCJhTvJg4iw0zTCxQ6H5tguN1Qepc+XD1NdlRTi8yicnEKSLcq20qzI3KxxwToNLnFKseSQ==",
+      "version": "1.17.3",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-symbol-file-dropzone/-/uui-symbol-file-dropzone-1.17.3.tgz",
+      "integrity": "sha512-g5SA+JqlTO6vNmH3vnSCNpj2tucOqGp6glaWWAWgq7ZttjOxMjwvRGBMc62/A31tlbUPI27vt7RPngWQeR+vmg==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.12.2"
+        "@umbraco-ui/uui-base": "1.17.3"
       }
     },
     "node_modules/@umbraco-ui/uui-symbol-file-thumbnail": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-symbol-file-thumbnail/-/uui-symbol-file-thumbnail-1.12.2.tgz",
-      "integrity": "sha512-tQsQTjgZti4zB327Xd2ql8lz9rj07aVwKfJcV2bClHwyQbRb370KRAS4m6MiaT587+6qVcjRwG3Sya1blpNMfg==",
+      "version": "1.17.3",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-symbol-file-thumbnail/-/uui-symbol-file-thumbnail-1.17.3.tgz",
+      "integrity": "sha512-x9ggQviV0sKzELCdDNlQvlc+0xo9bEokm4OG6+EwKRo6MzlOaGA/xmtMFwEX/NBgyydK3+hzw1P6mLK0hO8Lyw==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.12.2"
+        "@umbraco-ui/uui-base": "1.17.3"
       }
     },
     "node_modules/@umbraco-ui/uui-symbol-folder": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-symbol-folder/-/uui-symbol-folder-1.12.2.tgz",
-      "integrity": "sha512-v3bYEpbomOmt2J+LYuB3HqzzZW+LzK/Ufpvr3Km9Gl4eXjPUnrAzBn3PSdq7w5ZvR3vfEV017coPTSX0wncjKQ==",
+      "version": "1.17.3",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-symbol-folder/-/uui-symbol-folder-1.17.3.tgz",
+      "integrity": "sha512-v3LfxsNNbLXqXaxn/JqWys8rkuIo1agNVrgmw/zWG+XzIz0LhhQlVIv70lSW+kdVtNLzdy1LF64Eac3iSxgqVw==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.12.2"
+        "@umbraco-ui/uui-base": "1.17.3"
       }
     },
     "node_modules/@umbraco-ui/uui-symbol-lock": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-symbol-lock/-/uui-symbol-lock-1.12.2.tgz",
-      "integrity": "sha512-syW+kTYq7W9coBc7ov1BbDhRTmAMh77GacfQt4XSayHgE/hhO6UvG95uk0POaooQ0UfBW1bDv9r3/wJNZBTfmw==",
+      "version": "1.17.3",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-symbol-lock/-/uui-symbol-lock-1.17.3.tgz",
+      "integrity": "sha512-WZvGQXJw2tLx9asCLeMQS+leNy80AkMnyIPHGTxFXUa4o6csnGuwsBElfhXyaEUdMBsciwmNCuJsD9EY77dOfQ==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.12.2"
+        "@umbraco-ui/uui-base": "1.17.3"
       }
     },
     "node_modules/@umbraco-ui/uui-symbol-more": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-symbol-more/-/uui-symbol-more-1.12.2.tgz",
-      "integrity": "sha512-lxcw/B6zl3TJ7mZDYgXKvX6D/1gYYLmrLvKV7J5iSTGxDNiLji8NAXu2/rgffKMGIFaLfZicEENSLLX/JF8QGQ==",
+      "version": "1.17.3",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-symbol-more/-/uui-symbol-more-1.17.3.tgz",
+      "integrity": "sha512-BQ58zFIvGTRpLHfTCtI+rENdFViJWoBFgdMF5Y5wA6Li7/VPfzAAezcFvMhsoHFMojLvfoBqFkCkqjvaJPohTg==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.12.2"
+        "@umbraco-ui/uui-base": "1.17.3"
       }
     },
     "node_modules/@umbraco-ui/uui-symbol-sort": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-symbol-sort/-/uui-symbol-sort-1.12.2.tgz",
-      "integrity": "sha512-iDLs6Ph9BGrLRifU6oGZr7UCOsoOKk5NMxnP7eP/sy0geq30kHlI/mcBu6XUrtYiFsy3+l8b8gSFdLxEHQrcgQ==",
+      "version": "1.17.3",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-symbol-sort/-/uui-symbol-sort-1.17.3.tgz",
+      "integrity": "sha512-PulzS0gWeBxJobOAz6u7TFqX4TrzvjuVb1gqg0D4BednL1U7n7y1/dEmJlqVxDe9N6vcyls0yC4LuhiEIoxBwQ==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.12.2"
+        "@umbraco-ui/uui-base": "1.17.3"
       }
     },
     "node_modules/@umbraco-ui/uui-table": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-table/-/uui-table-1.12.2.tgz",
-      "integrity": "sha512-aHSArtedBiQBcz++eXomQvTys4Q0P7/SNEUcsG/CbPS7uDWXQZJK/KajtI7rMjU/d63dtavIXq9v0LatKTM/sw==",
+      "version": "1.17.3",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-table/-/uui-table-1.17.3.tgz",
+      "integrity": "sha512-HPpt5/nJNwtD/lvsvW4+piEPRoXYeHyAiELeoi2c/oy+9JUcBU1cGTEEBlAvqBVjuAPGE148EIF/aVSNrJ+GTg==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.12.2"
+        "@umbraco-ui/uui-base": "1.17.3"
       }
     },
     "node_modules/@umbraco-ui/uui-tabs": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-tabs/-/uui-tabs-1.12.2.tgz",
-      "integrity": "sha512-20ZmwGiLFtFA5a1CkBo713Ua508d0VwaCWnaKkhoE8Kl/ttlWhlKg+PSB26wkcwB0QonWrH1clMRalwKqRhjvg==",
+      "version": "1.17.3",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-tabs/-/uui-tabs-1.17.3.tgz",
+      "integrity": "sha512-+zytU/gm1TGfSSigeaZGF/zNzSue2UU9X3Mml7ThKBxJM+Fmhn+00I/d62yWhbOiN+o5n8HNKEKeUO62N0uw3g==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.12.2",
-        "@umbraco-ui/uui-button": "1.12.2",
-        "@umbraco-ui/uui-popover-container": "1.12.2",
-        "@umbraco-ui/uui-symbol-more": "1.12.2"
+        "@umbraco-ui/uui-base": "1.17.3",
+        "@umbraco-ui/uui-button": "1.17.3",
+        "@umbraco-ui/uui-popover-container": "1.17.3",
+        "@umbraco-ui/uui-symbol-more": "1.17.3"
       }
     },
     "node_modules/@umbraco-ui/uui-tag": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-tag/-/uui-tag-1.12.2.tgz",
-      "integrity": "sha512-15omQCZmBeW3U6E0kCoFQs3ckUsNqWOCjslGfDMe+0x0a+r5hntam05OrUlF523plD/SG6utXGI/tRYdTidh1g==",
+      "version": "1.17.3",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-tag/-/uui-tag-1.17.3.tgz",
+      "integrity": "sha512-B5noxWEAac2P7AJSg8iFNvZC+VxyMs2hb4sgEfagR2IfinPOTj7rDrKBU9ZjYfcUgiZFq4TUwvRxqPK+qce4SA==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.12.2"
+        "@umbraco-ui/uui-base": "1.17.3"
       }
     },
     "node_modules/@umbraco-ui/uui-textarea": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-textarea/-/uui-textarea-1.12.2.tgz",
-      "integrity": "sha512-dlT0fZ0zjdj4BouWhjqA4UBBj4YRFGxWZkMhbP/+g2lAnsl11GN2yMzOvfv7R6Zo3pmV6/qavtEk+XRKBaAihg==",
+      "version": "1.17.3",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-textarea/-/uui-textarea-1.17.3.tgz",
+      "integrity": "sha512-GrAJSwgsoZ8roWdHlL8WNoqmGjoznc3VnkBP6RYivrURpnCbvPVtl8iteWKfRxZfcBOIvI4johgiE4aae+ojTg==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.12.2"
+        "@umbraco-ui/uui-base": "1.17.3"
       }
     },
     "node_modules/@umbraco-ui/uui-toast-notification": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-toast-notification/-/uui-toast-notification-1.12.2.tgz",
-      "integrity": "sha512-gtVAoGPd4G0VWVdSyyhaDQupzuLLfFzuaVTVai0970hLAZAzcbodG3W382iPhPIbHwQX7T8LMV02ScPfGuhjbA==",
+      "version": "1.17.3",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-toast-notification/-/uui-toast-notification-1.17.3.tgz",
+      "integrity": "sha512-unykwkfV+ma0q9NTXdicICn61ilrEJlypdSdOzLCb5TiuR8jsPeeSsaMkVUEKs+JnJw5seh2kA95fUqKMCPeag==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.12.2",
-        "@umbraco-ui/uui-button": "1.12.2",
-        "@umbraco-ui/uui-css": "1.12.1",
-        "@umbraco-ui/uui-icon": "1.12.2",
-        "@umbraco-ui/uui-icon-registry-essential": "1.12.2"
+        "@umbraco-ui/uui-base": "1.17.3",
+        "@umbraco-ui/uui-button": "1.17.3",
+        "@umbraco-ui/uui-css": "1.17.3",
+        "@umbraco-ui/uui-icon": "1.17.3",
+        "@umbraco-ui/uui-icon-registry-essential": "1.17.3"
       }
     },
     "node_modules/@umbraco-ui/uui-toast-notification-container": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-toast-notification-container/-/uui-toast-notification-container-1.12.2.tgz",
-      "integrity": "sha512-Zu70rQzYV+QegV2kwNmpUDGU75z6u9B3ujFzVN2u+oi1y0kkR6wgXIczExQ4PeqEBZM252ZWbCIDQ66gX1+thw==",
+      "version": "1.17.3",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-toast-notification-container/-/uui-toast-notification-container-1.17.3.tgz",
+      "integrity": "sha512-pA8prAosV3Ga4UxQHeJ+a2sgXy4REb3PpZ2SKD7CnD0qNXsPfBm4sK5ewCHK2bbNnAgrMIHKNW97yOUMA9cicA==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.12.2",
-        "@umbraco-ui/uui-toast-notification": "1.12.2"
+        "@umbraco-ui/uui-base": "1.17.3",
+        "@umbraco-ui/uui-toast-notification": "1.17.3"
       }
     },
     "node_modules/@umbraco-ui/uui-toast-notification-layout": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-toast-notification-layout/-/uui-toast-notification-layout-1.12.2.tgz",
-      "integrity": "sha512-b0kgRwc744RpBjJW5URKRwGXzbGWU12OuFqIXq6BSl8LuFci9uh62V2J7Jj5xnx6v1jqZi/RRRKRwiqQOa3AWw==",
+      "version": "1.17.3",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-toast-notification-layout/-/uui-toast-notification-layout-1.17.3.tgz",
+      "integrity": "sha512-LZ2GMmjeV+dGNr8ZqQJqZOjFB3JuFdaazVkwLuqkVXpCg42j6QJKfzXsSLdY/tX4NJK3dAT06Xwxb+bMezrgEw==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.12.2",
-        "@umbraco-ui/uui-css": "1.12.1"
+        "@umbraco-ui/uui-base": "1.17.3",
+        "@umbraco-ui/uui-css": "1.17.3"
       }
     },
     "node_modules/@umbraco-ui/uui-toggle": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-toggle/-/uui-toggle-1.12.2.tgz",
-      "integrity": "sha512-hQCQJUEYjNL/2a/vldTlkFhTLiAF+P1UKxhPDqxCQlO/GsOihefcRhchOPmx4ptvjadvSc7J/MJPhAYC2RB0gw==",
+      "version": "1.17.3",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-toggle/-/uui-toggle-1.17.3.tgz",
+      "integrity": "sha512-GsSDkhOm4KR1kd9KkxTkdp4flN6Sv9Nr6rHHgk0cl6ojsfiAQa6hTXYma2ZRs90DpZpD10Ll6P3ka6ZudSq+gw==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.12.2",
-        "@umbraco-ui/uui-boolean-input": "1.12.2"
+        "@umbraco-ui/uui-base": "1.17.3",
+        "@umbraco-ui/uui-boolean-input": "1.17.3"
       }
     },
     "node_modules/@umbraco-ui/uui-visually-hidden": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-visually-hidden/-/uui-visually-hidden-1.12.2.tgz",
-      "integrity": "sha512-3VC4UUcalOl93pkwVWxbSxnIEyN9e5Soy+V3HKQDifWZ536NjBRvMzw+jib5BFLBzrfmRjX68lxNbE2t/EDydA==",
+      "version": "1.17.3",
+      "resolved": "https://registry.npmjs.org/@umbraco-ui/uui-visually-hidden/-/uui-visually-hidden-1.17.3.tgz",
+      "integrity": "sha512-DZTXqd0j7WuIWhNoFVn0B6rU+sbRHEhTqll5wU1lQTwz6XnGiXkmNC1YaIUy8GW9b3e22pTVzEjZ+kennOnPcQ==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@umbraco-ui/uui-base": "1.12.2"
+        "@umbraco-ui/uui-base": "1.17.3"
+      }
+    },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
+    },
+    "node_modules/ansi-colors": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
+      "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/argparse": {
@@ -2492,6 +2643,81 @@
       "license": "Python-2.0",
       "peer": true
     },
+    "node_modules/bundle-name": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
+      "integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "run-applescript": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/c12": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/c12/-/c12-3.3.4.tgz",
+      "integrity": "sha512-cM0ApFQSBXuourJejzwv/AuPRvAxordTyParRVcHjjtXirtkzM0uK2L9TTn9s0cXZbG7E55jCivRQzoxYmRAlA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "chokidar": "^5.0.0",
+        "confbox": "^0.2.4",
+        "defu": "^6.1.6",
+        "dotenv": "^17.3.1",
+        "exsolve": "^1.0.8",
+        "giget": "^3.2.0",
+        "jiti": "^2.6.1",
+        "ohash": "^2.0.11",
+        "pathe": "^2.0.3",
+        "perfect-debounce": "^2.1.0",
+        "pkg-types": "^2.3.0",
+        "rc9": "^3.0.1"
+      },
+      "peerDependencies": {
+        "magicast": "*"
+      },
+      "peerDependenciesMeta": {
+        "magicast": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
+      "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "readdirp": "^5.0.0"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/color-support": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
+      "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true,
+      "bin": {
+        "color-support": "bin.js"
+      }
+    },
     "node_modules/colord": {
       "version": "2.9.3",
       "resolved": "https://registry.npmjs.org/colord/-/colord-2.9.3.tgz",
@@ -2500,18 +2726,107 @@
       "license": "MIT",
       "peer": true
     },
-    "node_modules/crelt": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
-      "integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==",
+    "node_modules/commander": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/confbox": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.2.4.tgz",
+      "integrity": "sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/default-browser": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.5.0.tgz",
+      "integrity": "sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "bundle-name": "^4.1.0",
+        "default-browser-id": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/default-browser-id": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.1.tgz",
+      "integrity": "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/define-lazy-prop": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+      "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/defu": {
+      "version": "6.1.7",
+      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.7.tgz",
+      "integrity": "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/destr": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/destr/-/destr-2.0.5.tgz",
+      "integrity": "sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==",
       "dev": true,
       "license": "MIT",
       "peer": true
     },
     "node_modules/diff": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-7.0.0.tgz",
-      "integrity": "sha512-PJWHUb1RFevKCwaFA9RlG5tCd+FO5iRh9A8HEtkmBH2Li03iJriB6m6JIN4rGz3K3JLawI7/veA1xzRKP6ISBw==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-9.0.0.tgz",
+      "integrity": "sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw==",
       "dev": true,
       "license": "BSD-3-Clause",
       "peer": true,
@@ -2520,9 +2835,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.4.tgz",
-      "integrity": "sha512-ysFSFEDVduQpyhzAob/kkuJjf5zWkZD8/A9ywSp1byueyuCfHamrCBa14/Oc2iiB0e51B+NpxSl5gmzn+Ms/mg==",
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.3.tgz",
+      "integrity": "sha512-VVwJidIJcp1hpg2OMXML3ZVRPYSZiq4aX7qBh83BSIpOaRDqI+qxhXjjIWnpzkOXhmp0L81lnoME1mnCc9H48A==",
       "dev": true,
       "license": "(MPL-2.0 OR Apache-2.0)",
       "peer": true,
@@ -2530,27 +2845,27 @@
         "@types/trusted-types": "^2.0.7"
       }
     },
-    "node_modules/element-internals-polyfill": {
-      "version": "1.3.13",
-      "resolved": "https://registry.npmjs.org/element-internals-polyfill/-/element-internals-polyfill-1.3.13.tgz",
-      "integrity": "sha512-viZ7wJsvh6eFwGQX512zEaccK/c6RRFSerJsdkfe3DW/ZtruvNeOR33fpPZgfXxvqRdU2lK33KM4S6GqaTgVKQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/entities": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
-      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+    "node_modules/dotenv": {
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
       "dev": true,
       "license": "BSD-2-Clause",
       "peer": true,
       "engines": {
-        "node": ">=0.12"
+        "node": ">=12"
       },
       "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
+        "url": "https://dotenvx.com"
       }
+    },
+    "node_modules/element-internals-polyfill": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/element-internals-polyfill/-/element-internals-polyfill-3.0.2.tgz",
+      "integrity": "sha512-uB0/Qube3lkwh8SmkTnGIyUgJ9YdqVSzIoHMRCEQjAbD4Y5UzsVbch1tIxjTgUe5k3gy1U0ZMKMJ90A81lqwig==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/esbuild": {
       "version": "0.25.1",
@@ -2593,19 +2908,35 @@
         "@esbuild/win32-x64": "0.25.1"
       }
     },
-    "node_modules/escape-string-regexp": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "node": ">=6"
       }
+    },
+    "node_modules/eventsource": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-2.0.2.tgz",
+      "integrity": "sha512-IzUmBGPR3+oUG9dUeXynyNmf91/3zUSJg1lCktzKw47OXuhco54U3r9B7O4XX+Rb1Itm9OZ2b0RkTs10bICOxA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/exsolve": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.0.8.tgz",
+      "integrity": "sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/fdir": {
       "version": "6.5.0",
@@ -2625,6 +2956,18 @@
         }
       }
     },
+    "node_modules/fetch-cookie": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-cookie/-/fetch-cookie-2.2.0.tgz",
+      "integrity": "sha512-h9AgfjURuCgA2+2ISl8GbavpUdR+WGAM2McW/ovn4tVccegp8ZqCKWSBR8uRdM8dDNlx5WdKRWxBYUwteLDCNQ==",
+      "dev": true,
+      "license": "Unlicense",
+      "peer": true,
+      "dependencies": {
+        "set-cookie-parser": "^2.4.8",
+        "tough-cookie": "^4.0.0"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -2640,6 +2983,31 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/get-tsconfig": {
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
+      "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/giget": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/giget/-/giget-3.2.0.tgz",
+      "integrity": "sha512-GvHTWcykIR/fP8cj8dMpuMMkvaeJfPvYnhq0oW+chSeIr+ldX21ifU2Ms6KBoyKZQZmVaUAAhQ2EZ68KJF8a7A==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "giget": "dist/cli.mjs"
+      }
+    },
     "node_modules/iconoir": {
       "version": "7.11.0",
       "resolved": "https://registry.npmjs.org/iconoir/-/iconoir-7.11.0.tgz",
@@ -2650,55 +3018,145 @@
         "url": "https://opencollective.com/iconoir"
       }
     },
-    "node_modules/linkify-it": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
-      "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
+    "node_modules/is-docker": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+      "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-in-ssh": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-in-ssh/-/is-in-ssh-1.0.0.tgz",
+      "integrity": "sha512-jYa6Q9rH90kR1vKB6NM7qqd1mge3Fx4Dhw5TVlK1MUBqhEOuCagrEHMevNuCcbECmXZ0ThXkRm+Ymr51HwEPAw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-inside-container": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+      "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "uc.micro": "^2.0.0"
+        "is-docker": "^3.0.0"
+      },
+      "bin": {
+        "is-inside-container": "cli.js"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-wsl": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
+      "integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "is-inside-container": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true
+    },
+    "node_modules/jiti": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+      "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/linkifyjs": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/linkifyjs/-/linkifyjs-4.2.0.tgz",
-      "integrity": "sha512-pCj3PrQyATaoTYKHrgWRF3SJwsm61udVh+vuls/Rl6SptiDhgE7ziUIudAedRY9QEfynmM7/RmLEfPUyw1HPCw==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/linkifyjs/-/linkifyjs-4.3.3.tgz",
+      "integrity": "sha512-P8aEP5U/D1/IlTY2OeYsErdwh9bGuLE30NcXtKEjgdHcahveQoQwM2yZNsioQHsWFz0P7KKudisbrzCgR0sDHg==",
       "dev": true,
       "license": "MIT",
       "peer": true
     },
     "node_modules/lit": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/lit/-/lit-3.2.1.tgz",
-      "integrity": "sha512-1BBa1E/z0O9ye5fZprPtdqnc0BFzxIxTTOO/tQFmyC/hj1O3jL4TfmLBw0WEwjAokdLwpclkvGgDJwTIh0/22w==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-3.3.3.tgz",
+      "integrity": "sha512-fycuvZg/hkpozL00lm1pEJH5nN/lr9ZXd6mJI2HSN4+Bzc+LDNdEApJ6HFbPkdFNHLvOplIIuJvxkS4XUxqirw==",
       "dev": true,
       "license": "BSD-3-Clause",
       "peer": true,
       "dependencies": {
-        "@lit/reactive-element": "^2.0.4",
-        "lit-element": "^4.1.0",
-        "lit-html": "^3.2.0"
+        "@lit/reactive-element": "^2.1.0",
+        "lit-element": "^4.2.0",
+        "lit-html": "^3.3.0"
       }
     },
     "node_modules/lit-element": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.1.1.tgz",
-      "integrity": "sha512-HO9Tkkh34QkTeUmEdNYhMT8hzLid7YlMlATSi1q4q17HE5d9mrrEHJ/o8O2D0cMi182zK1F3v7x0PWFjrhXFew==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.2.2.tgz",
+      "integrity": "sha512-aFKhNToWxoyhkNDmWZwEva2SlQia+jfG0fjIWV//YeTaWrVnOxD89dPKfigCUspXFmjzOEUQpOkejH5Ly6sG0w==",
       "dev": true,
       "license": "BSD-3-Clause",
       "peer": true,
       "dependencies": {
-        "@lit-labs/ssr-dom-shim": "^1.2.0",
-        "@lit/reactive-element": "^2.0.4",
-        "lit-html": "^3.2.0"
+        "@lit-labs/ssr-dom-shim": "^1.5.0",
+        "@lit/reactive-element": "^2.1.0",
+        "lit-html": "^3.3.0"
       }
     },
     "node_modules/lit-html": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.2.1.tgz",
-      "integrity": "sha512-qI/3lziaPMSKsrwlxH/xMgikhQ0EGOX2ICU73Bi/YHFvz2j/yMCIrw4+puF2IpQ4+upd3EWbvnHM9+PnJn48YA==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.3.3.tgz",
+      "integrity": "sha512-el8M6jK2o3RXBnrSHX3ZKrsN8zEV63pSExTO1wYJz7QndGYZ8353e2a5PPX+qHe2aGayfnchQmkAojaWAREOIA==",
       "dev": true,
       "license": "BSD-3-Clause",
       "peer": true,
@@ -2706,29 +3164,58 @@
         "@types/trusted-types": "^2.0.2"
       }
     },
-    "node_modules/markdown-it": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.0.tgz",
-      "integrity": "sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==",
+    "node_modules/luxon": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.7.2.tgz",
+      "integrity": "sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/marked": {
+      "version": "18.0.3",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.3.tgz",
+      "integrity": "sha512-7VT90JOkDeaRWpfjOReRGPEKn0ecdARBkDGL+tT1wZY0efPPqkUxLUSmzy/C7TIylQYJC9STISEsCHrqb/7VIA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/monaco-editor": {
+      "version": "0.55.1",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.55.1.tgz",
+      "integrity": "sha512-jz4x+TJNFHwHtwuV9vA9rMujcZRb0CEilTEwG2rRSpe/A7Jdkuj8xPKttCgOh+v/lkHy7HsZ64oj+q3xoAFl9A==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "argparse": "^2.0.1",
-        "entities": "^4.4.0",
-        "linkify-it": "^5.0.0",
-        "mdurl": "^2.0.0",
-        "punycode.js": "^2.3.1",
-        "uc.micro": "^2.1.0"
-      },
-      "bin": {
-        "markdown-it": "bin/markdown-it.mjs"
+        "dompurify": "3.2.7",
+        "marked": "14.0.0"
       }
     },
-    "node_modules/marked": {
-      "version": "15.0.7",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-15.0.7.tgz",
-      "integrity": "sha512-dgLIeKGLx5FwziAnsk4ONoGwHwGPJzselimvlVskE9XLN4Orv9u2VA3GWw/lYUqjfA0rUT/6fqKwfZJapP9BEg==",
+    "node_modules/monaco-editor/node_modules/dompurify": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.7.tgz",
+      "integrity": "sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==",
+      "dev": true,
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "peer": true,
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
+    },
+    "node_modules/monaco-editor/node_modules/marked": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-14.0.0.tgz",
+      "integrity": "sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -2738,22 +3225,6 @@
       "engines": {
         "node": ">= 18"
       }
-    },
-    "node_modules/mdurl": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
-      "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/monaco-editor": {
-      "version": "0.52.2",
-      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.52.2.tgz",
-      "integrity": "sha512-GEQWEZmfkOGLdd3XK8ryrfWz3AIP8YymVXiPHEdewrUq7mh0qrKrfHLNCXcbB6sTnMLnOZ3ztSiKcciFUkIJwQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/nanoid": {
       "version": "3.3.11",
@@ -2774,10 +3245,89 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ohash": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz",
+      "integrity": "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/open": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-11.0.0.tgz",
+      "integrity": "sha512-smsWv2LzFjP03xmvFoJ331ss6h+jixfA4UUV/Bsiyuu4YJPfN+FIQGOIiv4w9/+MoHkfkJ22UIaQWRVFRfH6Vw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "default-browser": "^5.4.0",
+        "define-lazy-prop": "^3.0.0",
+        "is-in-ssh": "^1.0.0",
+        "is-inside-container": "^1.0.0",
+        "powershell-utils": "^0.1.0",
+        "wsl-utils": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/orderedmap": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/orderedmap/-/orderedmap-2.1.1.tgz",
       "integrity": "sha512-TvAWxi0nDe1j/rtMcWcIj94+Ffe6n7zhow33h40SKxmsmozs6dz/e+EajymfoFcHd7sxNn8yHM8839uixMOV6g==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/perfect-debounce": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-2.1.0.tgz",
+      "integrity": "sha512-LjgdTytVFXeUgtHZr9WYViYSM/g8MkcTPYDlPa3cDqMirHjKiSZPYd6DoL7pK8AJQr+uWkQvCjHNdiMqsrJs+g==",
       "dev": true,
       "license": "MIT",
       "peer": true
@@ -2800,6 +3350,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pkg-types": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-2.3.1.tgz",
+      "integrity": "sha512-y+ichcgc2LrADuhLNAx8DFjVfgz91pRxfZdI3UDhxHvcVEZsenLO+7XaU5vOp0u/7V/wZ+plyuQxtrDlZJ+yeg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "confbox": "^0.2.4",
+        "exsolve": "^1.0.8",
+        "pathe": "^2.0.3"
       }
     },
     "node_modules/postcss": {
@@ -2831,10 +3394,24 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/powershell-utils": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/powershell-utils/-/powershell-utils-0.1.0.tgz",
+      "integrity": "sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/prosemirror-changeset": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/prosemirror-changeset/-/prosemirror-changeset-2.2.1.tgz",
-      "integrity": "sha512-J7msc6wbxB4ekDFj+n9gTW/jav/p53kdlivvuppHsrZXCaQdVgRghoZbSS3kwrRyAstRVQ4/+u5k7YfLgkkQvQ==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-changeset/-/prosemirror-changeset-2.4.1.tgz",
+      "integrity": "sha512-96WBLhOaYhJ+kPhLg3uW359Tz6I/MfcrQfL4EGv4SrcqKEMC1gmoGrXHecPE8eOwTVCJ4IwgfzM8fFad25wNfw==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -2842,21 +3419,10 @@
         "prosemirror-transform": "^1.0.0"
       }
     },
-    "node_modules/prosemirror-collab": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/prosemirror-collab/-/prosemirror-collab-1.3.1.tgz",
-      "integrity": "sha512-4SnynYR9TTYaQVXd/ieUvsVV4PDMBzrq2xPUWutHivDuOshZXqQ5rGbZM84HEaXKbLdItse7weMGOUdDVcLKEQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "prosemirror-state": "^1.0.0"
-      }
-    },
     "node_modules/prosemirror-commands": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/prosemirror-commands/-/prosemirror-commands-1.7.0.tgz",
-      "integrity": "sha512-6toodS4R/Aah5pdsrIwnTYPEjW70SlO5a66oo5Kk+CIrgJz3ukOoS+FYDGqvQlAX5PxoGWDX1oD++tn5X3pyRA==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-commands/-/prosemirror-commands-1.7.1.tgz",
+      "integrity": "sha512-rT7qZnQtx5c0/y/KlYaGvtG411S97UaL6gdp6RIZ23DLHanMYLyfGBV5DtSnZdthQql7W+lEVbpSfwtO8T+L2w==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -2867,9 +3433,9 @@
       }
     },
     "node_modules/prosemirror-dropcursor": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/prosemirror-dropcursor/-/prosemirror-dropcursor-1.8.1.tgz",
-      "integrity": "sha512-M30WJdJZLyXHi3N8vxN6Zh5O8ZBbQCz0gURTfPmTIBNQ5pxrdU7A58QkNqfa98YEjSAL1HUyyU34f6Pm5xBSGw==",
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/prosemirror-dropcursor/-/prosemirror-dropcursor-1.8.2.tgz",
+      "integrity": "sha512-CCk6Gyx9+Tt2sbYk5NK0nB1ukHi2ryaRgadV/LvyNuO3ena1payM2z6Cg0vO1ebK8cxbzo41ku2DE5Axj1Zuiw==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -2880,9 +3446,9 @@
       }
     },
     "node_modules/prosemirror-gapcursor": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/prosemirror-gapcursor/-/prosemirror-gapcursor-1.3.2.tgz",
-      "integrity": "sha512-wtjswVBd2vaQRrnYZaBCbyDqr232Ed4p2QPtRIUK5FuqHYKGWkEwl08oQM4Tw7DOR0FsasARV5uJFvMZWxdNxQ==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-gapcursor/-/prosemirror-gapcursor-1.4.1.tgz",
+      "integrity": "sha512-pMdYaEnjNMSwl11yjEGtgTmLkR08m/Vl+Jj443167p9eB3HVQKhYCc4gmHVDsLPODfZfjr/MmirsdyZziXbQKw==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -2894,9 +3460,9 @@
       }
     },
     "node_modules/prosemirror-history": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/prosemirror-history/-/prosemirror-history-1.4.1.tgz",
-      "integrity": "sha512-2JZD8z2JviJrboD9cPuX/Sv/1ChFng+xh2tChQ2X4bB2HeK+rra/bmJ3xGntCcjhOqIzSDG6Id7e8RJ9QPXLEQ==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/prosemirror-history/-/prosemirror-history-1.5.0.tgz",
+      "integrity": "sha512-zlzTiH01eKA55UAf1MEjtssJeHnGxO0j4K4Dpx+gnmX9n+SHNlDqI2oO1Kv1iPN5B1dm5fsljCfqKF9nFL6HRg==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -2907,22 +3473,10 @@
         "rope-sequence": "^1.3.0"
       }
     },
-    "node_modules/prosemirror-inputrules": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/prosemirror-inputrules/-/prosemirror-inputrules-1.4.0.tgz",
-      "integrity": "sha512-6ygpPRuTJ2lcOXs9JkefieMst63wVJBgHZGl5QOytN7oSZs3Co/BYbc3Yx9zm9H37Bxw8kVzCnDsihsVsL4yEg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "prosemirror-state": "^1.0.0",
-        "prosemirror-transform": "^1.0.0"
-      }
-    },
     "node_modules/prosemirror-keymap": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/prosemirror-keymap/-/prosemirror-keymap-1.2.2.tgz",
-      "integrity": "sha512-EAlXoksqC6Vbocqc0GtzCruZEzYgrn+iiGnNjsJsH4mrnIGex4qbLdWWNza3AW5W36ZRrlBID0eM6bdKH4OStQ==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/prosemirror-keymap/-/prosemirror-keymap-1.2.3.tgz",
+      "integrity": "sha512-4HucRlpiLd1IPQQXNqeo81BGtkY8Ai5smHhKW9jjPKRc2wQIxksg7Hl1tTI2IfT2B/LgX6bfYvXxEpJl7aKYKw==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -2931,53 +3485,15 @@
         "w3c-keyname": "^2.2.0"
       }
     },
-    "node_modules/prosemirror-markdown": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/prosemirror-markdown/-/prosemirror-markdown-1.13.1.tgz",
-      "integrity": "sha512-Sl+oMfMtAjWtlcZoj/5L/Q39MpEnVZ840Xo330WJWUvgyhNmLBLN7MsHn07s53nG/KImevWHSE6fEj4q/GihHw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@types/markdown-it": "^14.0.0",
-        "markdown-it": "^14.0.0",
-        "prosemirror-model": "^1.20.0"
-      }
-    },
-    "node_modules/prosemirror-menu": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/prosemirror-menu/-/prosemirror-menu-1.2.4.tgz",
-      "integrity": "sha512-S/bXlc0ODQup6aiBbWVsX/eM+xJgCTAfMq/nLqaO5ID/am4wS0tTCIkzwytmao7ypEtjj39i7YbJjAgO20mIqA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "crelt": "^1.0.0",
-        "prosemirror-commands": "^1.0.0",
-        "prosemirror-history": "^1.0.0",
-        "prosemirror-state": "^1.0.0"
-      }
-    },
     "node_modules/prosemirror-model": {
-      "version": "1.24.1",
-      "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.24.1.tgz",
-      "integrity": "sha512-YM053N+vTThzlWJ/AtPtF1j0ebO36nvbmDy4U7qA2XQB8JVaQp1FmB9Jhrps8s+z+uxhhVTny4m20ptUvhk0Mg==",
+      "version": "1.25.5",
+      "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.25.5.tgz",
+      "integrity": "sha512-dWa0mfQAX8a63zmDILRvBMCM9hPVqDie/Ch4pbObAujGVyHvrRMDiW1sKKBpkj7dwjVLOZvSHAtek2AqQHnyPw==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "orderedmap": "^2.0.0"
-      }
-    },
-    "node_modules/prosemirror-schema-basic": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/prosemirror-schema-basic/-/prosemirror-schema-basic-1.2.3.tgz",
-      "integrity": "sha512-h+H0OQwZVqMon1PNn0AG9cTfx513zgIG2DY00eJ00Yvgb3UD+GQ/VlWW5rcaxacpCGT1Yx8nuhwXk4+QbXUfJA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "prosemirror-model": "^1.19.0"
       }
     },
     "node_modules/prosemirror-schema-list": {
@@ -2994,9 +3510,9 @@
       }
     },
     "node_modules/prosemirror-state": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/prosemirror-state/-/prosemirror-state-1.4.3.tgz",
-      "integrity": "sha512-goFKORVbvPuAQaXhpbemJFRKJ2aixr+AZMGiquiqKxaucC6hlpHNZHWgz5R7dS4roHiwq9vDctE//CZ++o0W1Q==",
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/prosemirror-state/-/prosemirror-state-1.4.4.tgz",
+      "integrity": "sha512-6jiYHH2CIGbCfnxdHbXZ12gySFY/fz/ulZE333G6bPqIZ4F+TXo9ifiR86nAHpWnfoNjOb3o5ESi7J8Uz1jXHw==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -3007,41 +3523,24 @@
       }
     },
     "node_modules/prosemirror-tables": {
-      "version": "1.6.4",
-      "resolved": "https://registry.npmjs.org/prosemirror-tables/-/prosemirror-tables-1.6.4.tgz",
-      "integrity": "sha512-TkDY3Gw52gRFRfRn2f4wJv5WOgAOXLJA2CQJYIJ5+kdFbfj3acR4JUW6LX2e1hiEBiUwvEhzH5a3cZ5YSztpIA==",
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/prosemirror-tables/-/prosemirror-tables-1.8.5.tgz",
+      "integrity": "sha512-V/0cDCsHKHe/tfWkeCmthNUcEp1IVO3p6vwN8XtwE9PZQLAZJigbw3QoraAdfJPir4NKJtNvOB8oYGKRl+t0Dw==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "prosemirror-keymap": "^1.2.2",
-        "prosemirror-model": "^1.24.1",
-        "prosemirror-state": "^1.4.3",
-        "prosemirror-transform": "^1.10.2",
-        "prosemirror-view": "^1.37.2"
-      }
-    },
-    "node_modules/prosemirror-trailing-node": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/prosemirror-trailing-node/-/prosemirror-trailing-node-3.0.0.tgz",
-      "integrity": "sha512-xiun5/3q0w5eRnGYfNlW1uU9W6x5MoFKWwq/0TIRgt09lv7Hcser2QYV8t4muXbEr+Fwo0geYn79Xs4GKywrRQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@remirror/core-constants": "3.0.0",
-        "escape-string-regexp": "^4.0.0"
-      },
-      "peerDependencies": {
-        "prosemirror-model": "^1.22.1",
-        "prosemirror-state": "^1.4.2",
-        "prosemirror-view": "^1.33.8"
+        "prosemirror-keymap": "^1.2.3",
+        "prosemirror-model": "^1.25.4",
+        "prosemirror-state": "^1.4.4",
+        "prosemirror-transform": "^1.10.5",
+        "prosemirror-view": "^1.41.4"
       }
     },
     "node_modules/prosemirror-transform": {
-      "version": "1.10.3",
-      "resolved": "https://registry.npmjs.org/prosemirror-transform/-/prosemirror-transform-1.10.3.tgz",
-      "integrity": "sha512-Nhh/+1kZGRINbEHmVu39oynhcap4hWTs/BlU7NnxWj3+l0qi8I1mu67v6mMdEe/ltD8hHvU4FV6PHiCw2VSpMw==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/prosemirror-transform/-/prosemirror-transform-1.12.0.tgz",
+      "integrity": "sha512-GxboyN4AMIsoHNtz5uf2r2Ru551i5hWeCMD6E2Ib4Eogqoub0NflniaBPVQ4MrGE5yZ8JV9tUHg9qcZTTrcN4w==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -3050,9 +3549,9 @@
       }
     },
     "node_modules/prosemirror-view": {
-      "version": "1.38.1",
-      "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.38.1.tgz",
-      "integrity": "sha512-4FH/uM1A4PNyrxXbD+RAbAsf0d/mM0D/wAKSVVWK7o0A9Q/oOXJBrw786mBf2Vnrs/Edly6dH6Z2gsb7zWwaUw==",
+      "version": "1.41.8",
+      "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.41.8.tgz",
+      "integrity": "sha512-TnKDdohEatgyZNGCDWIdccOHXhYloJwbwU+phw/a23KBvJIR9lWQWW7WHHK3vBdOLDNuF7TaX98GObUZOWkOnA==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -3062,15 +3561,83 @@
         "prosemirror-transform": "^1.1.0"
       }
     },
-    "node_modules/punycode.js": {
+    "node_modules/psl": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
+      "integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/lupomontero"
+      }
+    },
+    "node_modules/punycode": {
       "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
-      "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/rc9": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/rc9/-/rc9-3.0.1.tgz",
+      "integrity": "sha512-gMDyleLWVE+i6Sgtc0QbbY6pEKqYs97NGi6isHQPqYlLemPoO8dxQ3uGi0f4NiP98c+jMW6cG1Kx9dDwfvqARQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "defu": "^6.1.6",
+        "destr": "^2.0.5"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
+      "integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
     },
     "node_modules/rollup": {
@@ -3123,14 +3690,76 @@
       "license": "MIT",
       "peer": true
     },
-    "node_modules/rxjs": {
-      "version": "7.8.1",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
-      "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
+    "node_modules/run-applescript": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
+      "integrity": "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==",
       "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/rxjs": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "dev": true,
+      "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/source-map-js": {
@@ -3160,27 +3789,37 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
-    "node_modules/tinymce": {
-      "version": "6.8.5",
-      "resolved": "https://registry.npmjs.org/tinymce/-/tinymce-6.8.5.tgz",
-      "integrity": "sha512-qAL/FxL7cwZHj4BfaF818zeJJizK9jU5IQzTcSLL4Rj5MaJdiVblEj7aDr80VCV1w9h4Lak9hlnALhq/kVtN1g==",
+    "node_modules/tough-cookie": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.4.tgz",
+      "integrity": "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "dependencies": {
+        "psl": "^1.1.33",
+        "punycode": "^2.1.1",
+        "universalify": "^0.2.0",
+        "url-parse": "^1.5.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
     },
-    "node_modules/tinymce-i18n": {
-      "version": "24.12.30",
-      "resolved": "https://registry.npmjs.org/tinymce-i18n/-/tinymce-i18n-24.12.30.tgz",
-      "integrity": "sha512-OOtJfr9plrXT5fuvCEXJ56QFKyFPCaaVcalj0UgJGv2AK8PNWhDVqzPef6MPlBkvVA1qgrZb7ZvfJC63wmkWjg==",
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
       "dev": true,
       "license": "MIT",
       "peer": true
     },
     "node_modules/tslib": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true,
+      "license": "0BSD",
       "peer": true
     },
     "node_modules/typescript": {
@@ -3197,14 +3836,6 @@
         "node": ">=14.17"
       }
     },
-    "node_modules/uc.micro": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
-      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
-    },
     "node_modules/undici-types": {
       "version": "7.16.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
@@ -3212,10 +3843,33 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/universalify": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
+      "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/url-parse": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
+      }
+    },
     "node_modules/uuid": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
-      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "version": "13.0.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.2.tgz",
+      "integrity": "sha512-vzi9uRZ926x4XV73S/4qQaTwPXM2JBj6/6lI/byHH1jOpCzb0zDbfytgA9LcN/hzb2l7WQSQnxITOVx5un/wGw==",
       "dev": true,
       "funding": [
         "https://github.com/sponsors/broofa",
@@ -3224,7 +3878,7 @@
       "license": "MIT",
       "peer": true,
       "bin": {
-        "uuid": "dist/esm/bin/uuid"
+        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/vite": {
@@ -3309,6 +3963,84 @@
       "dev": true,
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "peer": true
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/ws": {
+      "version": "7.5.10",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/wsl-utils": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.3.1.tgz",
+      "integrity": "sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "is-wsl": "^3.1.0",
+        "powershell-utils": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     }
   }
 }

--- a/Umbraco.Community.IconPack.Iconoir/client/package.json
+++ b/Umbraco.Community.IconPack.Iconoir/client/package.json
@@ -12,7 +12,7 @@
   },
   "devDependencies": {
     "@types/node": "^24.9.1",
-    "@umbraco-cms/backoffice": "^15.3.1",
+    "@umbraco-cms/backoffice": "^17.4.0",
     "typescript": "^5.9.3",
     "vite": "^7.1.12"
   }

--- a/Umbraco.Community.IconPack.Iconoir/client/package.json
+++ b/Umbraco.Community.IconPack.Iconoir/client/package.json
@@ -11,9 +11,9 @@
     "iconoir": "^7.11.0"
   },
   "devDependencies": {
-    "@types/node": "^24.9.1",
+    "@types/node": "^25.8.0",
     "@umbraco-cms/backoffice": "^17.4.0",
-    "typescript": "^5.9.3",
-    "vite": "^7.1.12"
+    "typescript": "^6.0.3",
+    "vite": "^7.3.3"
   }
 }

--- a/Umbraco.Community.IconPack.Iconoir/client/scripts/GenerateIconPack.js
+++ b/Umbraco.Community.IconPack.Iconoir/client/scripts/GenerateIconPack.js
@@ -19,6 +19,8 @@ const run = async () => {
 
     const buildTime = new Date().toISOString();
 
+    const iconMetadata = await fetchIconMetadata(version);
+
     // Read all .svgs in the directory
     const iconFiles = readdir(svgDirectory, (err, files) => {
         if (err) {
@@ -121,6 +123,88 @@ export default icons;`;
             console.error('Error writing file:', err);
         }
     });
+}
+
+/**
+ * Fetches the Iconoir icons.csv from GitHub, which maps each icon filename to
+ * its category and comma-separated search tags. Tries the version-tagged URL
+ * first (so the metadata matches the exact npm release in use), then falls back
+ * to the main branch, and finally returns an empty Map so the build still
+ * succeeds when the network is unavailable or the tag doesn't exist yet.
+ */
+async function fetchIconMetadata(version) {
+    const urls = [
+        `https://raw.githubusercontent.com/iconoir-icons/iconoir/v${version}/iconoir.com/icons.csv`,
+        'https://raw.githubusercontent.com/iconoir-icons/iconoir/main/iconoir.com/icons.csv',
+    ];
+
+    for (const url of urls) {
+        try {
+            console.log(`Fetching icon metadata from: ${url}`);
+            const response = await fetch(url);
+            if (!response.ok) {
+                console.warn(`Got HTTP ${response.status} from ${url}, trying next URL`);
+                continue;
+            }
+            const csvText = await response.text();
+            const metadata = parseIconCsv(csvText);
+            console.log(`Fetched icon metadata for ${metadata.size} icons`);
+            return metadata;
+        } catch (e) {
+            console.warn(`Failed to fetch from ${url}: ${e.message}`);
+        }
+    }
+
+    console.warn('Could not fetch icon metadata — keywords/groups will be omitted from this build');
+    return new Map();
+}
+
+function parseIconCsv(csvText) {
+    const metadata = new Map();
+    const lines = csvText.split('\n');
+
+    // Skip header row: filename,category,tags
+    for (let i = 1; i < lines.length; i++) {
+        const line = lines[i].trim();
+        if (!line) continue;
+
+        const [filename, category, tagsRaw] = parseCsvLine(line);
+        if (!filename) continue;
+
+        const keywords = (tagsRaw ?? '')
+            .split(',')
+            .map(t => t.trim())
+            .filter(t => t.length > 0);
+
+        metadata.set(filename.trim(), {
+            keywords,
+            groups: category?.trim() ? [category.trim()] : [],
+        });
+    }
+
+    return metadata;
+}
+
+// Splits a single CSV line into fields, respecting double-quoted fields that
+// may contain commas (e.g. the tags column: "fly,jet,plane").
+function parseCsvLine(line) {
+    const fields = [];
+    let current = '';
+    let inQuotes = false;
+
+    for (let i = 0; i < line.length; i++) {
+        const char = line[i];
+        if (char === '"') {
+            inQuotes = !inQuotes;
+        } else if (char === ',' && !inQuotes) {
+            fields.push(current);
+            current = '';
+        } else {
+            current += char;
+        }
+    }
+    fields.push(current);
+    return fields;
 }
 
 function UpdateUmbracoPackageVersionWithNpmVersion(version) {

--- a/Umbraco.Community.IconPack.Iconoir/client/scripts/GenerateIconPack.js
+++ b/Umbraco.Community.IconPack.Iconoir/client/scripts/GenerateIconPack.js
@@ -39,7 +39,7 @@ const run = async () => {
 
         GenerateSvgJsModules(svgFiles, buildTime, version);
 
-        GenerateIconDictionary(svgFiles, buildTime, version);
+        GenerateIconDictionary(svgFiles, buildTime, version, iconMetadata);
 
         UpdateUmbracoPackageVersionWithNpmVersion(version);
     });    
@@ -82,10 +82,10 @@ export default \`${fileContent}\`;`;
     });
 };
 
-function GenerateIconDictionary(svgFileNames, buildTime, version){
+function GenerateIconDictionary(svgFileNames, buildTime, version, iconMetadata){
 
     console.log('Generating icon dictionary .ts file');
-    
+
     // Initialize an empty array for the icon dictionary
     const icons = [];
 
@@ -99,6 +99,15 @@ function GenerateIconDictionary(svgFileNames, buildTime, version){
             name: `iconoir-${baseName}`,
             path: `/App_Plugins/Umbraco.IconPack.Iconoir/Iconoir/${baseName}.js`,
         };
+
+        // Enrich with keywords and groups from the Iconoir CSV when available.
+        // Umbraco 17.4+ uses these for enhanced semantic icon search; older
+        // versions simply ignore the extra fields.
+        const meta = iconMetadata.get(baseName);
+        if (meta) {
+            if (meta.keywords.length > 0) icon.keywords = meta.keywords;
+            if (meta.groups.length > 0) icon.groups = meta.groups;
+        }
 
         // Add the icon object to the icon dictionary
         icons.push(icon);

--- a/build.ps1
+++ b/build.ps1
@@ -29,8 +29,12 @@ Write-Output "Iconoir NPM Package version: $version"
 # Go back to the previous directory
 Pop-Location
 
-# Pack the project into a NuGet package
-dotnet pack $projectFile --configuration $configuration --output $outputDirectory /p:Version=$version
+# Pack the project into a NuGet package.
+# The pack revision allows us to ship pack-level improvements (e.g. icon
+# keywords support) independently of a new Iconoir npm release.
+# Reset to 0 (or remove the suffix) when a new Iconoir version is picked up.
+$packRevision = 1
+dotnet pack $projectFile --configuration $configuration --output $outputDirectory /p:Version="$version.$packRevision"
 
 # Check if the pack was successful
 if ($LASTEXITCODE -eq 0) {


### PR DESCRIPTION
## Summary

Umbraco 17.4 extends `UmbIconDefinition` with optional `keywords`, `groups`, and `related` fields to power semantic icon search in the backoffice icon picker (see [umbraco/Umbraco-CMS#22436](https://github.com/umbraco/Umbraco-CMS/pull/22436)). This PR wires those fields into the Iconoir icon pack using data from the official [Iconoir icons CSV](https://github.com/iconoir-icons/iconoir/blob/main/iconoir.com/icons.csv), and brings the project up to date with the Umbraco 17.4 / .NET 10 toolchain.

- **Umbraco 17.4+**: `keywords` and `groups` are read by the icon picker for richer, semantic search (e.g. searching `"fly"` surfaces `iconoir-airplane`)
- **Pre-17.4**: not listed on Marketplace for this version; prior releases of the pack remain available

---

## Changes

### `Umbraco.Community.IconPack.Iconoir.csproj`

- `TargetFramework` bumped `net9.0` → `net10.0` (Umbraco 17.4 requires .NET 10)
- `Umbraco.Cms` bumped `15.3.1` → `17.4.0` — a bare NuGet version is minimum-inclusive (`≥ 17.4.0`), covering 17.4, 17.5, 18.x and beyond with no upper bound. Also resolves NU1902/NU1903 vulnerability warnings; `15.3.1` fell inside the known vulnerable range `≥ 15.3.1, < 16.5.1` (GHSA-rhcg-3h8r-v6vp et al.)
- `Description` updated to reflect keyword/group feature and 17.4+ target
- Stale `umbraco-v14` package tag removed

### `Umbraco.Community.IconPack.Iconoir.Website.csproj`

Updated to match the official `dotnet new umbraco` template for 17.4.0 exactly (verified by diffing against the release-17.4.0 tag on GitHub):

- `TargetFramework` `net9.0` → `net10.0`
- `Umbraco.Cms` `15.3.1` → `17.4.0`
- `<CompressionEnabled>false</CompressionEnabled>` added (required by 17.4 template to prevent compression of backoffice static files)
- `Microsoft.ICU.ICU4C.Runtime 72.1.0.3` unchanged — matches template

### `client/scripts/GenerateIconPack.js`

**Commit 1 — fetch and parse CSV metadata**

Adds three new functions:
- `fetchIconMetadata(version)` — downloads `iconoir.com/icons.csv` from GitHub at build time. Tries the version-tagged URL first (`v7.11.0/...`), falls back to `main`, and returns an empty `Map` if both fail so offline/CI builds are unaffected.
- `parseIconCsv(text)` — parses the CSV into a `Map<filename, { keywords, groups }>`
- `parseCsvLine(line)` — RFC-4180-style CSV field splitter that handles quoted fields containing commas (which the tags column uses)

**Commit 2 — populate keywords/groups in the generated dictionary**

`GenerateIconDictionary` now accepts the metadata map and conditionally adds `keywords` and `groups` to each icon entry:

```json
{
  "name": "iconoir-airplane",
  "path": "/App_Plugins/Umbraco.IconPack.Iconoir/Iconoir/airplane.js",
  "keywords": ["fly", "jet"],
  "groups": ["Transport"]
}
```

Icons absent from the CSV (or with no tags) still emit cleanly — `keywords` is omitted rather than set to `[]`, and `groups` is still added when a category exists.

### `client/package.json` + `package-lock.json`

- `@umbraco-cms/backoffice` `^15.3.1` → `^17.4.0` (devDependency — TypeScript compilation only, no runtime effect)
- `@types/node` `^24.9.1` → `^25.8.0`
- `typescript` `^5.9.3` → `^6.0.3`
- `vite` `^7.1.12` → `^7.3.3`

### `build.ps1`

Adds `$packRevision = 1` suffix, producing NuGet version `7.11.0.1`. Allows shipping pack-level improvements independently of a new Iconoir release. Reset when the next Iconoir version is adopted.

---

## CSV data source

```
https://raw.githubusercontent.com/iconoir-icons/iconoir/v7.11.0/iconoir.com/icons.csv
```

1383 icons — all verified to match the CSV exactly (zero keyword or group mismatches).

---

## Compatibility

| Umbraco version | Behaviour |
|---|---|
| < 17.4 | Not listed on Marketplace for this version; prior releases remain available |
| 17.4+ (including 18.x, 19.x…) | `keywords`/`groups` power semantic search in the backoffice icon picker |

---

## Test plan

- [x] `npm run build:iconpack` — logs `Fetched icon metadata for 1383 icons`, completes without error
- [x] `npm run build` — zero TypeScript errors, bundle produced successfully
- [x] Verification script: all 1383 icons match the CSV — zero keyword or group mismatches
- [x] `dotnet new umbraco` template for 17.4.0 diffed against website csproj — only `CompressionEnabled` was missing, now added
- [x] *(Manual)* Run the website, open backoffice icon picker, search `"fly"` — confirm `iconoir-airplane` surfaces

---

## References

- Umbraco CMS PR adding keyword support: https://github.com/umbraco/Umbraco-CMS/pull/22436
- Iconoir icons CSV: https://github.com/iconoir-icons/iconoir/blob/main/iconoir.com/icons.csv
- NuGet version range docs: https://learn.microsoft.com/en-us/nuget/concepts/package-versioning?tabs=semver20sort#version-ranges

---

<details>
<summary>Planning &amp; decision log (conversation with Claude Code)</summary>

This section captures the back-and-forth conversation that shaped the implementation, so reviewers can see not just *what* was decided but *why* and how the approach was steered.

---

**Warren:** Look at this PR from Umbraco 17.4 — https://github.com/umbraco/Umbraco-CMS/pull/22436. It adds a way to store different keywords against an icon. How can we do this so it will work for 17.4 for the new feature and prior versions it will just ignore it so it can work nicely for both? Iconoir for their own site has this CSV that has keywords that we could use — https://github.com/iconoir-icons/iconoir/blob/main/iconoir.com/icons.csv

**Claude:** Researched the Umbraco CMS PR and found that `UmbIconDefinition` gains three new **optional** fields in 17.4: `keywords`, `groups`, and `related`. Because they are optional, any Umbraco version that doesn't know about them will simply ignore them on the JS objects — no runtime breakage. The Iconoir CSV maps cleanly onto `keywords` (tags column) and `groups` (category column). Plan: fetch the CSV at build time in `GenerateIconPack.js`, try the version-tagged GitHub URL first, fall back to `main`, degrade gracefully to no keywords if both fail.

---

**Warren:** What should the next version of this package be?

**Claude:** The current scheme mirrors the Iconoir npm version. Since keywords is a pack-level change (not a new Iconoir release), proposed a `$packRevision` suffix in `build.ps1` (e.g. `7.11.0.1`) to allow independent pack releases.

---

**Warren:** Can you check the iconoir repo/npm version to see if there is something newer?

**Claude:** Checked npm registry and GitHub releases — `7.11.0` is the latest. Nothing to update; pack revision suffix confirmed as the right approach.

---

**Warren:** When working please work in a new branch. Do granular small commits. Create a PR with a description for a reviewer to explain changes and any code flow. Reference the Umbraco CMS PR and the CSV file.

**Claude:** Confirmed branch `claude/icon-keywords-compatibility-4DR4P`. Planned four granular commits: (1) fetch/parse CSV, (2) wire keywords/groups, (3) bump backoffice devDependency, (4) add pack revision to `build.ps1`.

---

**Warren:** If we have a test site in this repo should we update it to 17.4 to verify the changes with keyword?

**Claude:** Yes — recommended upgrading the website project to Umbraco 17.4 so keywords can be visually verified in the backoffice. Main package minimum stays at its existing value for broad compatibility; only the test site would move.

---

**Warren:** Perhaps I can do that myself manually.

**Claude:** Agreed — website upgrade removed from automated implementation; added as a manual step in the test plan.

---

**Warren:** Don't do step 6 to verify in the CMS — I can do that as well. Don't have any nice E2E Playwright tests for this.

**Claude:** Removed automated CMS verification. Build-time checks (CSV fetch, `icons.ts` spot-check, TypeScript compile) are the automated boundary; backoffice UI check stays manual.

---

**Warren:** Can we verify all icons got the correct tags assigned from the CSV?

**Claude:** Wrote and ran an inline Node.js verification script. Result: **1383/1383 icons correct — zero keyword mismatches, zero group mismatches, zero icons missing from the CSV.**

---

**Warren:** When I add this to a test site 17.4 I get NuGet vulnerability warnings (NU1902/NU1903) for `Umbraco.Cms 15.3.1`.

**Claude:** Initially suggested removing the `Umbraco.Cms` reference entirely, but Warren pointed out it is required for the Umbraco Marketplace listing (the Marketplace uses the dependency version to determine compatible Umbraco versions). Checked advisory GHSA-rhcg-3h8r-v6vp: affected range `≥ 15.3.1, < 16.5.1`; fixed in 16.5.1 and 17.2.2.

---

**Warren:** Should this version target 17.4+ as I suspect this will work in Umbraco 18 and other major versions?

**Claude:** Yes — `17.4.0` is the honest minimum (keywords only do anything in 17.4+), it's above the vulnerable range, and a bare NuGet version is minimum-inclusive so 18.x, 19.x etc. are covered automatically.

---

**Warren:** Is that correct for NuGet version for it to be an exact version set to 17.4.0?

**Claude:** Confirmed via Microsoft docs: `Version="17.4.0"` (bare) is minimum-inclusive (`x ≥ 17.4.0`). Only `[17.4.0]` with square brackets and no comma is exact. The docs also recommend not adding upper bounds to packages you don't own.

---

**Warren:** I get a `NU1202: Package Umbraco.Cms 17.4.0 is not compatible with net9.0` error in build.ps1.

**Claude:** Umbraco 17.4 moved to .NET 10. Fixed by bumping `TargetFramework` from `net9.0` to `net10.0` in the main package csproj.

---

**Warren:** Should we update the test site as well to 17.4.0 of Umbraco?

**Claude:** Yes — updated both `TargetFramework` and `Umbraco.Cms` version in the website csproj to match.

---

**Warren:** Use `dotnet new install Umbraco.Templates --force` and `dotnet new umbraco` to verify what a new Umbraco 17.4.0 site installs so we can do any comparison/updates.

**Claude:** .NET not available in this environment, so fetched the raw template csproj from the `release-17.4.0` GitHub tag instead. Diffed it against our website csproj — the only missing setting was `<CompressionEnabled>false</CompressionEnabled>`. Everything else (`Microsoft.ICU.ICU4C.Runtime 72.1.0.3`, `RuntimeHostConfigurationOption`, Razor settings) already matched. Added the missing property.

</details>